### PR TITLE
Release CLI 0.4.1, TypeScript SDK 0.3.2, Python SDK 1.7.2

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.1
+
+- Add `scorable skills-add` command to install Scorable skills for AI coding agents (`npx skills add root-signals/scorable-skills`)
+- Add usage demo video to README
+- Add "Install skills for your AI coding agent" step to `--help` getting-started section
+- Patch high-severity npm dependency vulnerabilities (undici, flatted, minimatch, rollup)
+
 ## 0.4.0
 
 - Add `scorable judge generate` command to generate a judge from an intent using AI

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",

--- a/cli/src/commands/prompt-test/index.ts
+++ b/cli/src/commands/prompt-test/index.ts
@@ -10,6 +10,6 @@ function buildPtGroup(name: string): Command {
 }
 
 export function registerPromptTestCommands(program: Command): void {
-  program.addCommand(buildPtGroup("pt"));
+  program.addCommand(buildPtGroup("pt"), { hidden: true });
   program.addCommand(buildPtGroup("prompt-test"));
 }

--- a/python/docs/CHANGELOG.md
+++ b/python/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.2
+
+- Patch high-severity dependency vulnerabilities (cryptography 46.0.5, urllib3 2.6.3)
+
 ## 1.7.1
 
 - Simplify multi-turn api

--- a/python/src/scorable/__about__.py
+++ b/python/src/scorable/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present juho.ylikyla <juho.ylikyla@scorable.ai>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.7.1"
+__version__ = "1.7.2"

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+- Patch high-severity dependency vulnerabilities (undici 7.24+, flatted 3.4.2+, minimatch, rollup 4.59+)
+
 ## 0.3.1
 
 - Expose `visibility`, `generating_model_params`, `judge_id`, `extra_contexts`, and `enable_context_aware_evaluators` in `judges.generate()`

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@root-signals/scorable",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@root-signals/scorable",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.15.0"
@@ -26,7 +26,7 @@
       },
       "optionalDependencies": {
         "form-data": "^4.0.5",
-        "undici": "^7.16.0"
+        "undici": "^7.24.5"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TypeScript SDK for Scorable API",
   "type": "module",
   "main": "dist/index.js",
@@ -55,7 +55,24 @@
   },
   "optionalDependencies": {
     "form-data": "^4.0.5",
-    "undici": "^7.16.0"
+    "undici": "^7.24.5"
+  },
+  "overrides": {
+    "flatted": ">=3.4.2",
+    "rollup": ">=4.60.0",
+    "minimatch": ">=9.0.9",
+    "@eslint/config-array": {
+      "minimatch": ">=3.1.4"
+    },
+    "@eslint/eslintrc": {
+      "minimatch": ">=3.1.4"
+    },
+    "eslint": {
+      "minimatch": ">=3.1.4"
+    },
+    "@redocly/openapi-core": {
+      "minimatch": ">=5.1.8"
+    }
   },
   "devDependencies": {
     "@types/node": "^24.10.1",


### PR DESCRIPTION
## Summary

- **CLI 0.4.1**: `scorable skills-add` command, README demo video, security dep patches
- **TypeScript SDK 0.3.2**: patch high-severity deps (undici 7.24+, flatted 3.4.2+, minimatch, rollup 4.59+)
- **Python SDK 1.7.2**: patch high-severity deps (cryptography 46.0.5, urllib3 2.6.3)

## Test plan

- [ ] `scorable --version` prints `0.4.1`
- [ ] `scorable skills-add` runs and prints post-install hint
- [ ] TypeScript SDK version is `0.3.2`
- [ ] Python SDK version is `1.7.2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new command to install Scorable skills for your AI coding agent
  * Added usage demonstration video to the documentation for guidance

* **Documentation**
  * Enhanced help section to include skill installation instructions

* **Bug Fixes**
  * Patched multiple high-severity security vulnerabilities in package dependencies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->