### PR TITLE
TypeScript SDK 0.4.0

### DIFF
--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0
+
+- Add `evaluators.exportYaml(id)` method to export an evaluator as a portable YAML string
+- Add `EvaluatorDemonstration` type export
+- Add `evaluator_demonstrations` field to `EvaluatorCreateParams`
+
 ## 0.3.2
 
 - Patch high-severity dependency vulnerabilities (undici 7.24+, flatted 3.4.2+, minimatch, rollup 4.59+)

--- a/typescript/eslint.config.mjs
+++ b/typescript/eslint.config.mjs
@@ -16,7 +16,8 @@ export default [
       globals: {
         setTimeout: 'readonly',
         setImmediate: 'readonly',
-        Buffer: 'readonly'
+        Buffer: 'readonly',
+        fetch: 'readonly'
       }
     },
     plugins: {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "TypeScript SDK for Scorable API",
   "type": "module",
   "main": "dist/index.js",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -41,7 +41,7 @@ export class Scorable {
     this.rateLimiter = new RateLimiter(this.config.rateLimit);
 
     // Initialize resources
-    this.evaluators = new EvaluatorsResource(this.client);
+    this.evaluators = new EvaluatorsResource(this.client, this.config);
     this.judges = new JudgesResource(this.client);
     this.objectives = new ObjectivesResource(this.client);
     this.models = new ModelsResource(this.client);

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -21,6 +21,7 @@ export type {
   EvaluatorListParams,
   EvaluatorCreateParams,
   EvaluatorUpdateParams,
+  EvaluatorDemonstration,
 } from './resources/evaluators.js';
 
 export type {

--- a/typescript/src/resources/evaluators.ts
+++ b/typescript/src/resources/evaluators.ts
@@ -1,5 +1,6 @@
 import type { paths, components } from '../generated/types.js';
 import {
+  ClientConfig,
   PaginatedResponse,
   ListParams,
   ScorableError,
@@ -13,6 +14,7 @@ export type EvaluatorListItem = components['schemas']['EvaluatorListOutput'];
 export type EvaluatorDetail = components['schemas']['Evaluator'];
 export type ExecutionResult = components['schemas']['EvaluatorExecutionResult'];
 export type EvaluatorRequest = components['schemas']['EvaluatorRequest'];
+export type EvaluatorDemonstration = components['schemas']['EvaluatorDemonstrationsRequest'];
 
 export interface EvaluatorWithExecute extends EvaluatorDetail {
   execute(payload: ExecutionPayload): Promise<ExecutionResult>;
@@ -35,6 +37,7 @@ export interface EvaluatorCreateParams {
   overwrite?: boolean;
   objective_id?: string;
   objective_version_id?: string;
+  evaluator_demonstrations?: EvaluatorDemonstration[];
 }
 
 export interface EvaluatorUpdateParams {
@@ -50,7 +53,10 @@ export interface EvaluatorUpdateParams {
 }
 
 export class EvaluatorsResource {
-  constructor(private _client: Client) {}
+  constructor(
+    private _client: Client,
+    private _config?: ClientConfig,
+  ) {}
 
   /**
    * List all accessible evaluators
@@ -193,6 +199,28 @@ export class EvaluatorsResource {
     }
   }
 
+  /**
+   * Export an evaluator as a portable YAML string.
+   * The returned YAML can be committed to a git repository and later imported
+   * back via the GitHub connector or the import endpoint.
+   */
+  async exportYaml(id: string): Promise<string> {
+    const baseUrl = this._config?.baseUrl ?? 'https://api.scorable.ai';
+    const apiKey = this._config?.apiKey ?? '';
+    const response = await fetch(`${baseUrl}/v1/evaluators/export/${id}/`, {
+      headers: { Authorization: `Api-Key ${apiKey}` },
+    });
+    if (!response.ok) {
+      throw new ScorableError(
+        response.status,
+        'EXPORT_EVALUATOR_FAILED',
+        {},
+        `Failed to export evaluator ${id}`,
+      );
+    }
+    return response.text();
+  }
+
   async create(params: EvaluatorCreateParams): Promise<EvaluatorWithExecute> {
     if (params.objective_id && params.intent) {
       throw new ScorableError(
@@ -251,6 +279,9 @@ export class EvaluatorsResource {
     }
     if (params.objective_version_id) {
       requestBody.objective_version_id = params.objective_version_id;
+    }
+    if (params.evaluator_demonstrations?.length) {
+      requestBody.evaluator_demonstrations = params.evaluator_demonstrations;
     }
 
     const { data, error } = await this._client.POST('/v1/evaluators/', {


### PR DESCRIPTION
## Summary

- Add `evaluators.exportYaml(id)` method to export an evaluator as a portable YAML string
- Add `EvaluatorDemonstration` type export
- Add `evaluator_demonstrations` field to `EvaluatorCreateParams`
- Fix `fetch` global in ESLint config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added evaluator export functionality to generate portable YAML files.
  * Extended evaluator creation to support demonstrations configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->