### PR TITLE
CLI 0.5.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0
+
+- Add `scorable evaluator export-yaml <id>` command to export an evaluator as a YAML file (prints to stdout or `--output <file>`)
+- Add `scorable evaluator import-yaml --file <path>` command to import an evaluator from a YAML file, with `--overwrite` support
+
 ## 0.4.1
 
 - Add `scorable skills-add` command to install Scorable skills for AI coding agents (`npx skills add root-signals/scorable-skills`)

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@root-signals/scorable-cli",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@root-signals/scorable": "^0.3.1",
+        "@root-signals/scorable": "^0.4.0",
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
@@ -1384,16 +1384,16 @@
       "license": "MIT"
     },
     "node_modules/@root-signals/scorable": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.3.1.tgz",
-      "integrity": "sha512-6r3NuwLDBqSmuKGhOxSScuG4LfSmEcBIBOJePsBe/UNnjWo1VsqIw8zs3mGiXLtsCF/i8zt3s2+kAMNkfSkKwg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.4.0.tgz",
+      "integrity": "sha512-wOlCzjMItx95I4nnu7mutatNEciT2NKNNizV1gfc+MAz3w49LS0SLivdX4FZxKX4u0q15zE+JXUqBbaX4J+eWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.15.0"
       },
       "optionalDependencies": {
         "form-data": "^4.0.5",
-        "undici": "^7.16.0"
+        "undici": "^7.24.5"
       }
     },
     "node_modules/@standard-schema/spec": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",
-    "@root-signals/scorable": "^0.3.1",
+    "@root-signals/scorable": "^0.4.0",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",

--- a/cli/src/commands/evaluator/export-yaml.ts
+++ b/cli/src/commands/evaluator/export-yaml.ts
@@ -1,0 +1,31 @@
+import { writeFileSync } from "node:fs";
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, handleSdkError } from "../../output.js";
+
+export function registerExportYamlCommand(evaluator: Command): void {
+  evaluator
+    .command("export-yaml")
+    .description("Export an evaluator as a YAML file")
+    .argument("<id>", "Evaluator ID")
+    .option("--output <file>", "Write YAML to this file instead of stdout")
+    .action(async (id: string, opts: { output?: string }) => {
+      const spinner = ora("Exporting…").start();
+      try {
+        const apiKey = await requireApiKey();
+        const client = getSdkClient(apiKey);
+        const yaml = await client.evaluators.exportYaml(id);
+        spinner.stop();
+        if (opts.output) {
+          writeFileSync(opts.output, yaml, "utf8");
+          printSuccess(`Evaluator exported to ${opts.output}`);
+        } else {
+          process.stdout.write(yaml);
+        }
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/evaluator/import-yaml.ts
+++ b/cli/src/commands/evaluator/import-yaml.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getBaseUrl } from "../../auth.js";
+import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
+
+export function registerImportYamlCommand(evaluator: Command): void {
+  evaluator
+    .command("import-yaml")
+    .description("Import an evaluator from a YAML file")
+    .requiredOption("--file <path>", "Path to the YAML file to import")
+    .option("--overwrite", "Overwrite if an evaluator with the same name already exists")
+    .action(async (opts: { file: string; overwrite?: boolean }) => {
+      let yamlContent: string;
+      try {
+        yamlContent = readFileSync(opts.file, "utf8");
+      } catch {
+        printError(`Could not read file: ${opts.file}`);
+        return;
+      }
+
+      const spinner = ora("Importing…").start();
+      try {
+        const apiKey = await requireApiKey();
+        const baseUrl = getBaseUrl();
+        const response = await fetch(`${baseUrl}/v1/evaluators/import-yaml/`, {
+          method: "POST",
+          headers: {
+            Authorization: `Api-Key ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ yaml: yamlContent, overwrite: opts.overwrite ?? false }),
+        });
+        if (!response.ok) {
+          spinner.stop();
+          const text = await response.text();
+          printError(`Import failed (${response.status}): ${text}`);
+          return;
+        }
+        const result = (await response.json()) as Record<string, unknown>;
+        spinner.stop();
+        const name = typeof result["name"] === "string" ? result["name"] : "evaluator";
+        printSuccess(`Evaluator "${name}" imported successfully!`);
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/evaluator/index.ts
+++ b/cli/src/commands/evaluator/index.ts
@@ -7,6 +7,8 @@ import { registerDeleteCommand } from "./delete.js";
 import { registerExecuteCommand } from "./execute.js";
 import { registerExecuteByNameCommand } from "./execute-by-name.js";
 import { registerDuplicateCommand } from "./duplicate.js";
+import { registerExportYamlCommand } from "./export-yaml.js";
+import { registerImportYamlCommand } from "./import-yaml.js";
 
 export function registerEvaluatorCommands(program: Command): void {
   const evaluator = new Command("evaluator").description("Evaluator management commands");
@@ -19,6 +21,8 @@ export function registerEvaluatorCommands(program: Command): void {
   registerExecuteCommand(evaluator);
   registerExecuteByNameCommand(evaluator);
   registerDuplicateCommand(evaluator);
+  registerExportYamlCommand(evaluator);
+  registerImportYamlCommand(evaluator);
 
   program.addCommand(evaluator);
 }

--- a/cli/tests/evaluator.test.ts
+++ b/cli/tests/evaluator.test.ts
@@ -6,6 +6,7 @@ import { executeEvaluatorByName } from "../src/commands/evaluator/execute-by-nam
 
 vi.mock("@root-signals/scorable");
 vi.mock("@inquirer/prompts");
+vi.mock("node:fs");
 
 const mockList = vi.fn();
 const mockGet = vi.fn();
@@ -15,6 +16,7 @@ const mockDelete = vi.fn();
 const mockExecute = vi.fn();
 const mockExecuteByName = vi.fn();
 const mockDuplicate = vi.fn();
+const mockExportYaml = vi.fn();
 
 const sampleEvaluator = {
   id: "eval-123",
@@ -37,6 +39,7 @@ beforeEach(() => {
         execute: mockExecute,
         executeByName: mockExecuteByName,
         duplicate: mockDuplicate,
+        exportYaml: mockExportYaml,
       },
     } as unknown as Scorable;
   });
@@ -568,5 +571,80 @@ describe("TestEvaluatorDuplicate", () => {
     const result = await runCli(["evaluator", "duplicate", "eval-123"]);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("Evaluator eval-123 duplicated successfully");
+  });
+});
+
+// --- TestEvaluatorExportYaml ---
+
+describe("TestEvaluatorExportYaml", () => {
+  it("test_export_yaml_prints_to_stdout", async () => {
+    const yaml = "name: Test Evaluator\nprompt: Does it work?\n";
+    mockExportYaml.mockResolvedValue(yaml);
+    const result = await runCli(["evaluator", "export-yaml", "eval-123"]);
+    expect(result.exitCode).toBe(0);
+    expect(mockExportYaml).toHaveBeenCalledWith("eval-123");
+  });
+
+  it("test_export_yaml_writes_to_file", async () => {
+    const { writeFileSync } = await import("node:fs");
+    const yaml = "name: Test Evaluator\nprompt: Does it work?\n";
+    mockExportYaml.mockResolvedValue(yaml);
+    const result = await runCli(["evaluator", "export-yaml", "eval-123", "--output", "out.yaml"]);
+    expect(result.exitCode).toBe(0);
+    expect(vi.mocked(writeFileSync)).toHaveBeenCalledWith("out.yaml", yaml, "utf8");
+    expect(result.stdout).toContain("out.yaml");
+  });
+
+  it("test_export_yaml_api_error", async () => {
+    mockExportYaml.mockRejectedValue(new Error("Not found"));
+    const result = await runCli(["evaluator", "export-yaml", "eval-123"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("Not found");
+  });
+});
+
+// --- TestEvaluatorImportYaml ---
+
+describe("TestEvaluatorImportYaml", () => {
+  it("test_import_yaml_success", async () => {
+    const { readFileSync } = await import("node:fs");
+    const yaml = "name: Imported Evaluator\nprompt: Does it work?\n";
+    vi.mocked(readFileSync).mockReturnValue(yaml);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ name: "Imported Evaluator", id: "eval-new" }),
+      }),
+    );
+    const result = await runCli(["evaluator", "import-yaml", "--file", "eval.yaml"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Imported Evaluator");
+  });
+
+  it("test_import_yaml_file_not_found", async () => {
+    const { readFileSync } = await import("node:fs");
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const result = await runCli(["evaluator", "import-yaml", "--file", "missing.yaml"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("Could not read file");
+  });
+
+  it("test_import_yaml_api_error", async () => {
+    const { readFileSync } = await import("node:fs");
+    vi.mocked(readFileSync).mockReturnValue("name: Bad Evaluator\n");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => "Invalid YAML",
+      }),
+    );
+    const result = await runCli(["evaluator", "import-yaml", "--file", "eval.yaml"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("Import failed");
   });
 });


### PR DESCRIPTION
## Summary

- Add `scorable evaluator export-yaml <id>` command to export an evaluator as YAML (stdout or `--output <file>`)
- Add `scorable evaluator import-yaml --file <path>` command to import an evaluator from YAML, with `--overwrite` support
- Bump `@root-signals/scorable` dependency to `^0.4.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `export-yaml <id>` to export evaluators as YAML (stdout or `--output`).
  * Added `import-yaml --file <path>` to import evaluators from YAML with `--overwrite` support.
* **Chore**
  * CLI package updated to v0.5.0.
* **Tests**
  * Added test coverage for YAML export/import commands and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->