### PR TITLE
Release Python SDK 1.8.0 and TypeScript SDK 0.5.0

### DIFF
--- a/python/docs/CHANGELOG.md
+++ b/python/docs/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.8.0
+
+- Simplify visibility model: replace multi-value `status` field with `private`/`public` visibility
+- Remove `status` parameter from judge and evaluator creation
+- Update `generate()`/`agenerate()` visibility to accept `"private"`, `"public"`, `"global"` (default: `"private"`)
+- Remove deprecated RAGAS preset evaluators: `Answer_Relevance`, `Answer_Semantic_Similarity`, `Context_Precision`, `Context_Recall`, `Answer_Correctness`
+- Remove `pii_filter`, `reference_variables`, `model_params`, `system_message` from skills API
+
 ## 1.7.2
 
 - Patch high-severity dependency vulnerabilities (cryptography 46.0.5, urllib3 2.6.3)

--- a/python/src/scorable/__about__.py
+++ b/python/src/scorable/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present juho.ylikyla <juho.ylikyla@scorable.ai>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.7.2"
+__version__ = "1.8.0"

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.5.0
+
+- Simplify visibility model: replace multi-value `status` field with `private`/`public` visibility
+- Remove `status` from `EvaluatorCreateParams`, `EvaluatorUpdateParams`, and `CreateJudgeData`
+- Remove `updateStatus()` from `DatasetsResource`
+- Update `judges.generate()` default visibility to `"private"`; accept `"private"`, `"public"`, `"global"`
+- Replace `is_public` list filter with `include_public` for evaluators and judges
+- Add required `variables` default (`{}`) to evaluator execute calls
+
 ## 0.4.0
 
 - Add `evaluators.exportYaml(id)` method to export an evaluator as a portable YAML string

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "TypeScript SDK for Scorable API",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Python SDK 1.8.0

- Simplify visibility model: replace multi-value `status` field with `private`/`public` visibility
- Remove `status` parameter from judge and evaluator creation
- Update `generate()`/`agenerate()` visibility to accept `"private"`, `"public"`, `"global"` (default: `"private"`)
- Remove deprecated RAGAS preset evaluators: `Answer_Relevance`, `Answer_Semantic_Similarity`, `Context_Precision`, `Context_Recall`, `Answer_Correctness`
- Remove `pii_filter`, `reference_variables`, `model_params`, `system_message` from skills API

## TypeScript SDK 0.5.0

- Simplify visibility model: replace multi-value `status` field with `private`/`public` visibility
- Remove `status` from `EvaluatorCreateParams`, `EvaluatorUpdateParams`, and `CreateJudgeData`
- Remove `updateStatus()` from `DatasetsResource`
- Update `judges.generate()` default visibility to `"private"`; accept `"private"`, `"public"`, `"global"`
- Replace `is_public` list filter with `include_public` for evaluators and judges
- Add required `variables` default (`{}`) to evaluator execute calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Visibility model simplified; status parameter removed from judge and evaluator creation
  * Deprecated evaluators removed from Python SDK
  * Updated filtering and parameter requirements in both SDKs

* **Version Updates**
  * Python SDK: v1.8.0
  * TypeScript SDK: v0.5.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->