### PR TITLE
CLI visibility simplification + restore stages/missing_context i

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.0
+
+- Simplify visibility model: `--visibility` now accepts `private` or `public` (default: `private`)
+- Remove `--system-message` option from `evaluator create` and `evaluator update`
+- Judge `generate`: remove stages and missing-context output; error codes are surfaced directly
+- Judge `list`: remove stale `is_public` default filter
+
 ## 0.5.0
 
 - Add `scorable evaluator export-yaml <id>` command to export an evaluator as a YAML file (prints to stdout or `--output <file>`)

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@root-signals/scorable-cli",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@root-signals/scorable": "^0.4.0",
+        "@root-signals/scorable": "^0.5.0",
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
@@ -1384,9 +1384,9 @@
       "license": "MIT"
     },
     "node_modules/@root-signals/scorable": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.4.0.tgz",
-      "integrity": "sha512-wOlCzjMItx95I4nnu7mutatNEciT2NKNNizV1gfc+MAz3w49LS0SLivdX4FZxKX4u0q15zE+JXUqBbaX4J+eWg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.5.0.tgz",
+      "integrity": "sha512-KSQ0B5NXTScxBQb/VL5GU+nSCjlTgSqmslWD6R7YO7v5YuMf9o1e+Oti+bAs8aJmmkqQz/KSeq3G8zy2Vu7oOg==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.15.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",
-    "@root-signals/scorable": "^0.4.0",
+    "@root-signals/scorable": "^0.5.0",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",

--- a/cli/src/commands/evaluator/create.ts
+++ b/cli/src/commands/evaluator/create.ts
@@ -18,7 +18,6 @@ export function registerCreateCommand(evaluator: Command): void {
       "The intent for the evaluator (mutually exclusive with --objective-id)",
     )
     .option("--objective-id <id>", "Objective ID (mutually exclusive with --intent)")
-    .option("--system-message <text>", "System message for the evaluator")
     .option(
       "--models <json>",
       "JSON array of model names, in priority order. E.g., '[\"gpt-5-mini\"]'",
@@ -31,7 +30,6 @@ export function registerCreateCommand(evaluator: Command): void {
         scoringCriteria: string;
         intent?: string;
         objectiveId?: string;
-        systemMessage?: string;
         models?: string;
         overwrite?: boolean;
         objectiveVersionId?: string;
@@ -59,7 +57,6 @@ export function registerCreateCommand(evaluator: Command): void {
 
         if (opts.intent) payload.intent = opts.intent;
         if (opts.objectiveId) payload.objective_id = opts.objectiveId;
-        if (opts.systemMessage) payload.system_message = opts.systemMessage;
         if (opts.overwrite !== undefined) payload.overwrite = opts.overwrite;
         if (opts.objectiveVersionId) payload.objective_version_id = opts.objectiveVersionId;
 

--- a/cli/src/commands/evaluator/update.ts
+++ b/cli/src/commands/evaluator/update.ts
@@ -10,7 +10,6 @@ export function registerUpdateCommand(evaluator: Command): void {
     .description("Update an existing evaluator (PATCH)")
     .option("--name <name>", "The new name for the evaluator")
     .option("--scoring-criteria <text>", "The new scoring criteria (prompt text)")
-    .option("--system-message <text>", "The new system message")
     .option("--models <json>", "JSON array of model names. E.g., '[\"gpt-4\"]'")
     .option("--objective-id <id>", "The new objective ID")
     .option("--objective-version-id <id>", "The new objective version ID")
@@ -20,7 +19,6 @@ export function registerUpdateCommand(evaluator: Command): void {
         opts: {
           name?: string;
           scoringCriteria?: string;
-          systemMessage?: string;
           models?: string;
           objectiveId?: string;
           objectiveVersionId?: string;
@@ -31,7 +29,6 @@ export function registerUpdateCommand(evaluator: Command): void {
         const payload: EvaluatorUpdateParams = {};
         if (opts.name !== undefined) payload.name = opts.name;
         if (opts.scoringCriteria !== undefined) payload.prompt = opts.scoringCriteria;
-        if (opts.systemMessage !== undefined) payload.system_message = opts.systemMessage;
         if (opts.objectiveId !== undefined) payload.objective_id = opts.objectiveId;
         if (opts.objectiveVersionId !== undefined)
           payload.objective_version_id = opts.objectiveVersionId;

--- a/cli/src/commands/judge/generate.ts
+++ b/cli/src/commands/judge/generate.ts
@@ -63,8 +63,6 @@ offer to connect the guest with a human agent when uncertain."`,
           throw new CliError(1, "invalid_visibility");
         }
 
-        const apiVisibility = visibility === "private" ? "unlisted" : "public";
-
         const apiKey = await requireApiKey();
 
         let extra_contexts: Record<string, string> | undefined;
@@ -80,9 +78,10 @@ offer to connect the guest with a human agent when uncertain."`,
         const spinner = ora("Generating judge (this may take a moment)...").start();
         try {
           const client = getSdkClient(apiKey);
-          const result = await client.judges.generate({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const result = (await client.judges.generate({
             intent: opts.intent,
-            visibility: apiVisibility,
+            visibility: visibility as "private" | "public",
             overwrite: opts.overwrite,
             name: opts.name,
             stage: opts.stage,
@@ -94,7 +93,7 @@ offer to connect the guest with a human agent when uncertain."`,
                 reasoning_effort: opts.reasoningEffort as "off" | "low" | "medium" | "high",
               },
             }),
-          });
+          })) as any;
           spinner.stop();
 
           if (result.error_code === "multiple_stages") {

--- a/cli/src/commands/judge/list.ts
+++ b/cli/src/commands/judge/list.ts
@@ -23,7 +23,7 @@ export function registerListCommand(judge: Command): void {
       }) => {
         const apiKey = await requireApiKey();
 
-        const params: JudgeListParams & { name?: string } = { is_public: false };
+        const params: JudgeListParams & { name?: string } = {};
         if (opts.pageSize !== undefined) params.page_size = opts.pageSize;
         if (opts.cursor !== undefined) params.cursor = opts.cursor;
         if (opts.search !== undefined) params.search = opts.search;

--- a/cli/tests/judge.test.ts
+++ b/cli/tests/judge.test.ts
@@ -100,7 +100,6 @@ describe("TestJudgeList", () => {
         page_size: 10,
         search: "test",
         name: "Test Judge",
-        is_public: false,
       }),
     );
   });

--- a/typescript/src/generated/types.ts
+++ b/typescript/src/generated/types.ts
@@ -1089,8 +1089,6 @@ export interface components {
     };
     GenerationModelParamsRequest: {
       seed?: number | null;
-      /** Format: double */
-      temperature?: number | null;
       /** @default off */
       reasoning_effort: components['schemas']['ReasoningEffortEnum'];
     };
@@ -1278,7 +1276,7 @@ export interface components {
       } | null;
       intent: string;
       stage?: string | null;
-      visibility: components['schemas']['JudgeGeneratorVisibilityEnum'];
+      visibility: components['schemas']['VisibilityEf8Enum'];
       /** Format: uuid */
       file_id?: string | null;
       /** @default true */
@@ -1306,14 +1304,13 @@ export interface components {
       judge_version_id: string;
       error_code?: string | null;
       claim_token?: string | null;
+      missing_context_from_system_goal?:
+        | {
+            [key: string]: string;
+          }[]
+        | null;
+      stages?: string[] | null;
     };
-    /**
-     * @description * `global` - global
-     *     * `public` - public
-     *     * `private` - private
-     * @enum {string}
-     */
-    JudgeGeneratorVisibilityEnum: 'global' | 'public' | 'private';
     JudgeInviteRequest: {
       /** @description List of email addresses to send the invite to (maximum 10) */
       emails: string[];
@@ -1533,7 +1530,6 @@ export interface components {
       /** Format: uuid */
       readonly id: string;
       intent?: string;
-      status?: components['schemas']['StatusEnum'];
     };
     NestedUserDetails: {
       /**
@@ -1550,7 +1546,6 @@ export interface components {
       /** Format: uuid */
       readonly id: string;
       intent?: string;
-      status?: components['schemas']['StatusEnum'];
       /** @description Deprecated: Use test_dataset_id instead. */
       readonly test_set: string[][] | null;
       /** Format: date-time */
@@ -1569,7 +1564,6 @@ export interface components {
       /** Format: uuid */
       readonly id: string;
       intent?: string;
-      status?: components['schemas']['StatusEnum'];
       readonly owner: components['schemas']['NestedUserDetails'];
       /** Format: date-time */
       readonly created_at: string;
@@ -1580,7 +1574,6 @@ export interface components {
     };
     ObjectiveRequest: {
       intent?: string;
-      status?: components['schemas']['StatusEnum'];
       /** @description Force creation of a new objective. Applies only to PUT requests. */
       force_create?: boolean;
       /** Format: uuid */
@@ -1746,7 +1739,6 @@ export interface components {
     };
     PatchedObjectiveRequest: {
       intent?: string;
-      status?: components['schemas']['StatusEnum'];
       /** @description Force creation of a new objective. Applies only to PUT requests. */
       force_create?: boolean;
       /** Format: uuid */

--- a/typescript/src/resources/judges.ts
+++ b/typescript/src/resources/judges.ts
@@ -27,7 +27,7 @@ export type JudgeGeneratorResponse = components['schemas']['JudgeGeneratorRespon
 
 export interface JudgeGenerateParams {
   intent: string;
-  visibility?: components['schemas']['JudgeGeneratorVisibilityEnum'];
+  visibility?: components['schemas']['VisibilityEf8Enum'];
   stage?: string;
   overwrite?: boolean;
   name?: string;

--- a/typescript/tests/comprehensive.test.ts
+++ b/typescript/tests/comprehensive.test.ts
@@ -308,7 +308,7 @@ describe.skipIf(!runComprehensiveTests)('Scorable SDK Comprehensive Tests', () =
             status: 'listed',
           });
           expect(patched.id).toBe(createdObjectiveId);
-          expect(patched.status).toBe('listed');
+          expect((patched as any).status).toBe('listed');
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
         }


### PR DESCRIPTION
- CLI: visibility now private/public (default private), remove --system-message, clean up judge list/generate
- TypeScript types: restore stages and missing_context_from_system_goal fields to JudgeGeneratorResponse (were incorrectly dropped in 0.5.0 schema)
- Fix comprehensive test: objectives no longer have status field in schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI version 0.6.0 released with updated behavior for visibility and system message handling.

* **Breaking Changes**
  * `--visibility` flag now only accepts `private` or `public` values (defaults to `private`).
  * `--system-message` option removed from `evaluator create` and `evaluator update` commands.
  * `judge list` command no longer applies a default visibility filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->