### PR TITLE
feat(cli): otel-filter + otel-trace commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -258,6 +258,124 @@ Options: `--page-size`, `--cursor`, `--search`, `--evaluator-id`, `--judge-id`, 
 scorable execution-log get <log_id>
 ```
 
+## OTEL Trace Evaluation Filters
+
+When traces arrive at Scorable's OTLP endpoint, evaluation filters automatically run an evaluator or judge against each matching trace. Results land back on the same trace as a child span carrying the OpenTelemetry GenAI evaluation attributes (`gen_ai.evaluation.name`, `gen_ai.evaluation.score.value`, `gen_ai.evaluation.explanation`).
+
+### Create a filter
+
+```bash
+scorable otel-filter create \
+  --name "default-truthfulness" \
+  --evaluator-id <evaluator-uuid>
+```
+
+Required: `--name` and exactly one of `--evaluator-id` or `--judge-id`. A judge target emits one eval span per inner evaluator.
+
+Options: `--filter-criteria` (JSON of conditions), `--sampling-rate` (0.0–1.0, default 1.0), `--delay-seconds` (default 10, allows late spans to land before evaluation), `--inactive`
+
+Match traces from a specific service, run a 5-second-delayed evaluation:
+
+```bash
+scorable otel-filter create \
+  --name "agent-truthfulness" \
+  --evaluator-id <evaluator-uuid> \
+  --filter-criteria '{"conditions":[{"column":"resource","type":"string","key":"service.name","operator":"=","value":"my_agent"}]}' \
+  --delay-seconds 5
+```
+
+Multi-evaluator judge target:
+
+```bash
+scorable otel-filter create --name "quality-judge" --judge-id <judge-uuid>
+```
+
+### List filters
+
+```bash
+scorable otel-filter list
+```
+
+### Delete a filter
+
+```bash
+scorable otel-filter delete <filter_id>
+```
+
+## OTEL Trace Querying
+
+### List traces
+
+```bash
+scorable otel-trace list
+```
+
+Options: `--since` / `--start-time` / `--end-time` (time window), `--page-size`, `--cursor`, `--output table|json|csv` (default `table`), `--filter` (repeatable raw expression), plus convenience shortcuts below.
+
+Convenience flags — cover the common case, AND-combined with each other and with `--filter`:
+
+| Flag                    | Effect                                 |
+| ----------------------- | -------------------------------------- |
+| `--service-name <name>` | match `resource.service.name = <name>` |
+| `--has-error`           | only traces where some span errored    |
+| `--root-name <substr>`  | substring match on the root span name  |
+| `--span-name <substr>`  | substring match on any span's name     |
+| `--agent-name <name>`   | match `gen_ai.agent.name`              |
+| `--model <name>`        | match `gen_ai.request.model`           |
+| `--tool <name>`         | match `gen_ai.tool.name`               |
+
+Time-window flags (mutually exclusive group):
+
+```bash
+scorable otel-trace list --since 1h          # last hour
+scorable otel-trace list --since 7d
+scorable otel-trace list --start-time 2026-04-30T00:00:00Z --end-time 2026-05-01T00:00:00Z
+```
+
+Common one-liners:
+
+```bash
+# All traces from a specific agent in the last 24h, exported as CSV
+scorable otel-trace list --since 24h --service-name my_agent --output csv > traces.csv
+
+# Errored traces this week
+scorable otel-trace list --since 7d --has-error
+
+# Drill into traces that hit a specific tool
+scorable otel-trace list --tool fetch_customer_data
+```
+
+For anything the shortcuts don't cover, use `--filter` directly. Format: `column;type;key;operator;value`, repeatable, AND-combined. If your instrumentation follows the OpenTelemetry [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/) — pydantic-ai, OpenLLMetry, Logfire, OpenAI/Anthropic SDKs with otel all do — every documented attribute is filterable without extra setup.
+
+```bash
+# Expensive runs — over 5k input tokens
+scorable otel-trace list --since 24h \
+  --filter 'gen_ai.usage.input_tokens;number;gen_ai.usage.input_tokens;>;5000'
+
+# Multi-turn conversation drill-down
+scorable otel-trace list \
+  --filter 'gen_ai.conversation.id;string;gen_ai.conversation.id;=;conv_5j66'
+
+# Filter on Scorable's own evaluation result spans
+scorable otel-trace list \
+  --filter 'gen_ai.evaluation.name;string;gen_ai.evaluation.name;=;Truthfulness'
+```
+
+See `scorable otel-trace list --help` for the full column / operator / type reference.
+
+### Inspect spans for a trace
+
+```bash
+scorable otel-trace spans <trace_id>
+```
+
+Options: `--output table|json|csv`. The JSON form returns the full span payload — attributes, events, status, kind, `resource_attributes` — which is what you typically want for debugging or piping to `jq`.
+
+```bash
+scorable otel-trace spans <trace_id> --output json | jq '.[0].span.attributes'
+scorable otel-trace spans <trace_id> --output csv > spans.csv
+```
+
 ## Prompt Testing
 
 Initialize a config file and run experiments:

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -6,16 +6,30 @@ const { version } = createRequire(import.meta.url)("../package.json") as {
   version: string;
 };
 
-export async function apiRequest(
+interface RequestOptions {
+  payload?: Record<string, unknown>;
+  params?: Record<string, unknown>;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export interface ApiRequestResult {
+  ok: boolean;
+  status: number;
+  data: unknown;
+}
+
+// Returns the full HTTP outcome — `ok` is `false` on network/HTTP/decode errors
+// (in which case the helper has already printed an error to stderr) and `true`
+// on 2xx responses including 204 No Content (where `data` is `null`). Use this
+// when the caller needs to distinguish success-with-no-body from a failure
+// (e.g. DELETE handlers, where both currently surface as `null` from
+// `apiRequest`).
+export async function apiRequestStatus(
   method: string,
   endpoint: string,
-  options?: {
-    payload?: Record<string, unknown>;
-    params?: Record<string, unknown>;
-    apiKey?: string;
-    baseUrl?: string;
-  },
-): Promise<unknown> {
+  options?: RequestOptions,
+): Promise<ApiRequestResult> {
   const apiKey = options?.apiKey ?? getApiKey();
   const baseUrl = options?.baseUrl ?? getBaseUrl();
 
@@ -46,10 +60,10 @@ export async function apiRequest(
     });
   } catch (e) {
     printError(`Request failed: ${e instanceof Error ? e.message : String(e)}`);
-    return null;
+    return { ok: false, status: 0, data: null };
   }
 
-  if (response.status === 204) return null;
+  if (response.status === 204) return { ok: true, status: 204, data: null };
 
   if (!response.ok) {
     printError(`API Error: ${response.status} for ${method} ${url}`);
@@ -58,13 +72,25 @@ export async function apiRequest(
     } catch {
       printError(`Response content: ${await response.text().catch(() => "")}`);
     }
-    return null;
+    return { ok: false, status: response.status, data: null };
   }
 
   try {
-    return await response.json();
+    return { ok: true, status: response.status, data: await response.json() };
   } catch {
     printError(`Failed to decode JSON response from API for ${url}.`);
-    return null;
+    return { ok: false, status: response.status, data: null };
   }
+}
+
+// Convenience wrapper preserving the original `data | null` contract: returns
+// `null` on both 204 and any failure. Prefer `apiRequestStatus` when the
+// caller needs to tell those apart.
+export async function apiRequest(
+  method: string,
+  endpoint: string,
+  options?: RequestOptions,
+): Promise<unknown> {
+  const result = await apiRequestStatus(method, endpoint, options);
+  return result.ok ? result.data : null;
 }

--- a/cli/src/commands/otel-filter/create.ts
+++ b/cli/src/commands/otel-filter/create.ts
@@ -17,10 +17,18 @@ interface CreateOptions {
 export function registerCreateCommand(otelFilter: Command): void {
   otelFilter
     .command("create")
-    .description("Create a new OTEL trace evaluation filter")
+    .description(
+      "Create a new OTEL trace evaluation filter. Wires either an evaluator OR a judge to incoming traces.",
+    )
     .requiredOption("--name <name>", "Filter name")
-    .option("--evaluator-id <id>", "Evaluator UUID (mutually exclusive with --judge-id)")
-    .option("--judge-id <id>", "Judge UUID (mutually exclusive with --evaluator-id)")
+    .option(
+      "--evaluator-id <id>",
+      "Evaluator UUID to run on matching traces (mutually exclusive with --judge-id)",
+    )
+    .option(
+      "--judge-id <id>",
+      "Judge UUID to run on matching traces (mutually exclusive with --evaluator-id)",
+    )
     .option(
       "--filter-criteria <json>",
       'Filter conditions as JSON, e.g. \'{"conditions":[{"column":"name","type":"string","key":"name","operator":"contains","value":"agent"}]}\'',
@@ -31,23 +39,37 @@ export function registerCreateCommand(otelFilter: Command): void {
     .addHelpText(
       "after",
       `
+Target — exactly one of --evaluator-id or --judge-id is required.
+  --evaluator-id  Runs a single evaluator (one score, one justification).
+  --judge-id      Runs a judge — a bundle of evaluators that produces an
+                  aggregate verdict plus per-evaluator scores. Use this
+                  when you've already authored a judge for the agent
+                  you're tracing.
+
 Examples:
-  # Match every span and run an evaluator
+  # Match every span and run a single evaluator
   $ scorable otel-filter create \\
       --name "default-truthfulness" \\
-      --evaluator-id <uuid>
+      --evaluator-id <evaluator-uuid>
 
-  # Match only traces from a specific service (resource attribute)
+  # Run a judge (multi-evaluator) on every trace from a service
+  $ scorable otel-filter create \\
+      --name "construction-quality-judge" \\
+      --judge-id <judge-uuid> \\
+      --filter-criteria '{"conditions":[{"column":"resource","type":"string","key":"service.name","operator":"=","value":"construction_assistant_agent"}]}' \\
+      --delay-seconds 5
+
+  # Match only traces from a specific service (resource attribute), evaluator target
   $ scorable otel-filter create \\
       --name "construction-truthfulness" \\
-      --evaluator-id <uuid> \\
+      --evaluator-id <evaluator-uuid> \\
       --filter-criteria '{"conditions":[{"column":"resource","type":"string","key":"service.name","operator":"=","value":"construction_assistant_agent"}]}' \\
       --delay-seconds 5
 
   # Match by span attribute (gen_ai semantic conventions)
   $ scorable otel-filter create \\
       --name "agent-truthfulness" \\
-      --evaluator-id <uuid> \\
+      --evaluator-id <evaluator-uuid> \\
       --filter-criteria '{"conditions":[{"column":"gen_ai.agent.name","type":"string","key":"gen_ai.agent.name","operator":"=","value":"my_agent"}]}'`,
     )
     .action(async (opts: CreateOptions) => {

--- a/cli/src/commands/otel-filter/create.ts
+++ b/cli/src/commands/otel-filter/create.ts
@@ -1,0 +1,110 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey } from "../../auth.js";
+import { apiRequest } from "../../client.js";
+import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
+
+interface CreateOptions {
+  name: string;
+  evaluatorId?: string;
+  judgeId?: string;
+  filterCriteria?: string;
+  samplingRate?: string;
+  delaySeconds?: string;
+  inactive?: boolean;
+}
+
+export function registerCreateCommand(otelFilter: Command): void {
+  otelFilter
+    .command("create")
+    .description("Create a new OTEL trace evaluation filter")
+    .requiredOption("--name <name>", "Filter name")
+    .option("--evaluator-id <id>", "Evaluator UUID (mutually exclusive with --judge-id)")
+    .option("--judge-id <id>", "Judge UUID (mutually exclusive with --evaluator-id)")
+    .option(
+      "--filter-criteria <json>",
+      'Filter conditions as JSON, e.g. \'{"conditions":[{"column":"name","type":"string","key":"name","operator":"contains","value":"agent"}]}\'',
+    )
+    .option("--sampling-rate <rate>", "Sampling rate between 0.0 and 1.0", "1.0")
+    .option("--delay-seconds <seconds>", "Delay before evaluation (allows late spans)", "10")
+    .option("--inactive", "Create the filter as inactive", false)
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # Match every span and run an evaluator
+  $ scorable otel-filter create \\
+      --name "default-truthfulness" \\
+      --evaluator-id <uuid>
+
+  # Match only traces from a specific service (resource attribute)
+  $ scorable otel-filter create \\
+      --name "construction-truthfulness" \\
+      --evaluator-id <uuid> \\
+      --filter-criteria '{"conditions":[{"column":"resource","type":"string","key":"service.name","operator":"=","value":"construction_assistant_agent"}]}' \\
+      --delay-seconds 5
+
+  # Match by span attribute (gen_ai semantic conventions)
+  $ scorable otel-filter create \\
+      --name "agent-truthfulness" \\
+      --evaluator-id <uuid> \\
+      --filter-criteria '{"conditions":[{"column":"gen_ai.agent.name","type":"string","key":"gen_ai.agent.name","operator":"=","value":"my_agent"}]}'`,
+    )
+    .action(async (opts: CreateOptions) => {
+      if (!opts.evaluatorId && !opts.judgeId) {
+        printError("Either --evaluator-id or --judge-id is required.");
+        process.exit(1);
+      }
+      if (opts.evaluatorId && opts.judgeId) {
+        printError("--evaluator-id and --judge-id are mutually exclusive.");
+        process.exit(1);
+      }
+
+      let filterCriteria: Record<string, unknown> = {};
+      if (opts.filterCriteria) {
+        try {
+          filterCriteria = JSON.parse(opts.filterCriteria) as Record<string, unknown>;
+        } catch {
+          printError("Invalid JSON for --filter-criteria.");
+          process.exit(1);
+        }
+      }
+
+      const samplingRate = parseFloat(opts.samplingRate ?? "1.0");
+      if (Number.isNaN(samplingRate) || samplingRate < 0 || samplingRate > 1) {
+        printError("--sampling-rate must be a number between 0.0 and 1.0.");
+        process.exit(1);
+      }
+
+      const delaySeconds = parseInt(opts.delaySeconds ?? "10", 10);
+      if (Number.isNaN(delaySeconds) || delaySeconds < 0) {
+        printError("--delay-seconds must be a non-negative integer.");
+        process.exit(1);
+      }
+
+      const payload: Record<string, unknown> = {
+        name: opts.name,
+        filter_criteria: filterCriteria,
+        sampling_rate: samplingRate,
+        delay_seconds: delaySeconds,
+        is_active: !opts.inactive,
+      };
+      if (opts.evaluatorId) payload.evaluator_id = opts.evaluatorId;
+      if (opts.judgeId) payload.judge_id = opts.judgeId;
+
+      const spinner = ora("Creating filter...").start();
+      try {
+        const apiKey = await requireApiKey();
+        const result = await apiRequest("POST", "v1/otel/evaluation-filters", { payload, apiKey });
+        spinner.stop();
+        if (result === null) {
+          throw new Error("Filter creation failed.");
+        }
+        printSuccess("Filter created.");
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/otel-filter/delete.ts
+++ b/cli/src/commands/otel-filter/delete.ts
@@ -1,0 +1,31 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey } from "../../auth.js";
+import { apiRequestStatus } from "../../client.js";
+import { printSuccess, handleSdkError } from "../../output.js";
+
+export function registerDeleteCommand(otelFilter: Command): void {
+  otelFilter
+    .command("delete <id>")
+    .description("Delete an OTEL trace evaluation filter")
+    .action(async (id: string) => {
+      const spinner = ora("Deleting...").start();
+      try {
+        const apiKey = await requireApiKey();
+        const { ok } = await apiRequestStatus(
+          "DELETE",
+          `v1/otel/evaluation-filters/${encodeURIComponent(id)}`,
+          { apiKey },
+        );
+        spinner.stop();
+        if (!ok) {
+          // apiRequestStatus already printed the underlying error.
+          process.exit(1);
+        }
+        printSuccess(`Filter ${id} deleted.`);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/otel-filter/index.ts
+++ b/cli/src/commands/otel-filter/index.ts
@@ -1,0 +1,14 @@
+import { Command } from "commander";
+import { registerCreateCommand } from "./create.js";
+import { registerListCommand } from "./list.js";
+import { registerDeleteCommand } from "./delete.js";
+
+export function registerOtelFilterCommands(program: Command): void {
+  const otelFilter = program
+    .command("otel-filter")
+    .description("Manage OTEL trace evaluation filters");
+
+  registerCreateCommand(otelFilter);
+  registerListCommand(otelFilter);
+  registerDeleteCommand(otelFilter);
+}

--- a/cli/src/commands/otel-filter/list.ts
+++ b/cli/src/commands/otel-filter/list.ts
@@ -1,0 +1,31 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey } from "../../auth.js";
+import { apiRequest } from "../../client.js";
+import { printJson, handleSdkError, printMessage } from "../../output.js";
+
+export function registerListCommand(otelFilter: Command): void {
+  otelFilter
+    .command("list")
+    .description("List OTEL trace evaluation filters")
+    .action(async () => {
+      const spinner = ora("Fetching...").start();
+      try {
+        const apiKey = await requireApiKey();
+        const result = await apiRequest("GET", "v1/otel/evaluation-filters", { apiKey });
+        spinner.stop();
+        if (result === null) {
+          // apiRequest already reported the failure; don't masquerade it as "no filters".
+          process.exit(1);
+        }
+        if (Array.isArray(result) && result.length === 0) {
+          printMessage("No filters found.");
+          return;
+        }
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/otel-trace/index.ts
+++ b/cli/src/commands/otel-trace/index.ts
@@ -1,0 +1,12 @@
+import { Command } from "commander";
+import { registerListCommand } from "./list.js";
+import { registerSpansCommand } from "./spans.js";
+
+export function registerOtelTraceCommands(program: Command): void {
+  const otelTrace = program
+    .command("otel-trace")
+    .description("Query OTEL traces ingested by Scorable");
+
+  registerListCommand(otelTrace);
+  registerSpansCommand(otelTrace);
+}

--- a/cli/src/commands/otel-trace/list.ts
+++ b/cli/src/commands/otel-trace/list.ts
@@ -1,0 +1,335 @@
+import { Command } from "commander";
+import ora from "ora";
+import chalk from "chalk";
+import Table from "cli-table3";
+import { requireApiKey } from "../../auth.js";
+import { apiRequest } from "../../client.js";
+import { printJson, printMessage, printInfo, handleSdkError } from "../../output.js";
+import { buildTimeFilters, parseOutputFormat, resolveTimeWindow, toCsv } from "./shared.js";
+
+interface TraceRecord {
+  trace_id: string;
+  root_span_name: string;
+  first_span_at: string;
+  last_span_at: string;
+  span_count: number;
+  input_preview: string;
+  output_preview: string;
+}
+
+interface PaginatedTraces {
+  next: string | null;
+  previous: string | null;
+  results: TraceRecord[];
+}
+
+const UNICODE_CHARS = {
+  top: "─",
+  "top-mid": "┬",
+  "top-left": "┌",
+  "top-right": "┐",
+  bottom: "─",
+  "bottom-mid": "┴",
+  "bottom-left": "└",
+  "bottom-right": "┘",
+  left: "│",
+  "left-mid": "├",
+  mid: "─",
+  "mid-mid": "┼",
+  right: "│",
+  "right-mid": "┤",
+  middle: "│",
+};
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}
+
+function printTraceTable(traces: TraceRecord[]): void {
+  const table = new Table({
+    head: ["Trace ID", "Root Span", "Spans", "First Span"].map((h) => chalk.bold.cyan(h)),
+    chars: UNICODE_CHARS,
+    colWidths: [34, 42, 7, 22],
+    wordWrap: true,
+  });
+
+  for (const t of traces) {
+    const ts = (t.first_span_at ?? "").slice(0, 19).replace("T", " ");
+    table.push([t.trace_id, truncate(t.root_span_name ?? "", 40), String(t.span_count), ts]);
+  }
+  console.log(table.toString());
+}
+
+function printTraceCsv(traces: TraceRecord[]): void {
+  const headers = [
+    "trace_id",
+    "root_span_name",
+    "span_count",
+    "first_span_at",
+    "last_span_at",
+    "input_preview",
+    "output_preview",
+  ];
+  const rows = traces.map((t) => [
+    t.trace_id,
+    t.root_span_name,
+    t.span_count,
+    t.first_span_at,
+    t.last_span_at,
+    t.input_preview,
+    t.output_preview,
+  ]);
+  process.stdout.write(toCsv(headers, rows));
+}
+
+export function registerListCommand(otelTrace: Command): void {
+  otelTrace
+    .command("list")
+    .description("List ingested OTEL traces, optionally filtered")
+    .option(
+      "--filter <expr>",
+      "Filter expression (repeatable). Format: `column;type;key;operator;value`. See examples below.",
+      (value: string, previous: string[] = []) => [...previous, value],
+      [] as string[],
+    )
+    .option(
+      "--since <duration>",
+      "Only traces from the last <duration>. Forms: 30s, 5m, 2h, 7d. Mutually exclusive with --start-time/--end-time.",
+    )
+    .option(
+      "--start-time <iso>",
+      "Earliest first_span_at, inclusive (ISO 8601, e.g. 2026-04-30T00:00:00Z)",
+    )
+    .option("--end-time <iso>", "Latest first_span_at, exclusive (ISO 8601). Defaults to now.")
+    .option("--service-name <name>", "Match resource.service.name (=). Shortcut for --filter.")
+    .option(
+      "--has-error",
+      "Only traces where some span ended with status ERROR. Shortcut for --filter.",
+    )
+    .option("--root-name <substr>", "Substring match on the root span name. Shortcut for --filter.")
+    .option("--span-name <substr>", "Substring match on any span's name. Shortcut for --filter.")
+    .option("--agent-name <name>", "Match gen_ai.agent.name (=). Shortcut for --filter.")
+    .option("--model <name>", "Match gen_ai.request.model (=). Shortcut for --filter.")
+    .option("--tool <name>", "Match gen_ai.tool.name (=). Shortcut for --filter.")
+    .option("--page-size <n>", "Number of traces per page", (v) => parseInt(v, 10), 25)
+    .option("--cursor <cursor>", "Pagination cursor (from a previous `next` response)")
+    .option("--output <format>", "Output format: table | json | csv", "table")
+    .addHelpText(
+      "after",
+      `
+Filtering — three layers, pick the lowest one that fits
+
+  1. Convenience flags (covers ~80% of queries):
+       --service-name <name>     resource.service.name = <name>
+       --has-error               at least one span errored
+       --root-name <substr>      root span name contains <substr>
+       --span-name <substr>      any span name contains <substr>
+       --agent-name <name>       gen_ai.agent.name = <name>
+       --model <name>            gen_ai.request.model = <name>
+       --tool <name>             gen_ai.tool.name = <name>
+     All composable with each other and with --filter (AND-combined).
+
+  2. Time-window shortcuts:
+       --since 30s | 5m | 2h | 7d
+       --start-time / --end-time  ISO 8601 (inclusive start, exclusive end)
+     Mutually exclusive group; compile down to first_span_at filters.
+
+  3. Raw --filter (full power, anything the matcher supports):
+     One expression per --filter, repeatable, AND-combined.
+
+Raw filter expression format
+  column;type;key;operator;value
+
+  column  - what to match against (see "Columns" below)
+  type    - value type: string | number | boolean | datetime | stringOptions
+  key     - same as column for built-ins; for sentinel columns
+            (resource, attribute) this is the attribute name
+  operator - one of: = != contains "starts with" "any of" "none of"
+             > >= < <= (numeric and datetime)
+  value   - the value to match. For "any of" / "none of",
+            pipe-separate multiple values: ok|error|unset.
+            For datetime, ISO 8601: 2026-04-30T00:00:00Z
+
+Columns
+  Trace-record level (per-trace metadata):
+    name             root span name
+    span_count       total spans in trace
+    first_span_at    earliest span timestamp (datetime)
+    last_span_at     latest span timestamp (datetime)
+    input_preview    first input message snippet
+    output_preview   final output snippet
+
+  Span level (matches if any span in the trace satisfies):
+    span_name        span name (e.g. "agent run", "execute_tool")
+    has_error        boolean: span ended with status code ERROR
+    kind             1=INTERNAL 2=SERVER 3=CLIENT 4=PRODUCER 5=CONSUMER
+    status           OK | ERROR | UNSET (use "any of" / "none of")
+
+  Sentinel columns (key carries the attribute name):
+    resource         resource attribute, e.g. service.name
+    <attribute-key>  any span attribute. If your instrumentation follows the
+                     OpenTelemetry GenAI semantic conventions (pydantic-ai,
+                     OpenLLMetry, Logfire, OpenAI/Anthropic SDKs with otel
+                     all do), every documented attribute is filterable here
+                     without extra setup. Common ones:
+
+                       Request:    gen_ai.request.model
+                                   gen_ai.request.temperature
+                                   gen_ai.request.max_tokens
+                       Response:   gen_ai.response.model
+                                   gen_ai.response.finish_reasons
+                       Agent/Op:   gen_ai.agent.name / .id / .version
+                                   gen_ai.operation.name (chat|embeddings|...)
+                                   gen_ai.workflow.name
+                                   gen_ai.provider.name (openai|aws.bedrock|...)
+                       Tools:      gen_ai.tool.name / .type / .call.id
+                       Tracking:   gen_ai.conversation.id
+                       Tokens:     gen_ai.usage.input_tokens
+                                   gen_ai.usage.output_tokens
+                                   gen_ai.usage.reasoning.output_tokens
+                                   gen_ai.usage.cache_read.input_tokens
+
+                     Full registry:
+                       https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/
+
+Examples — convenience flags (the common case)
+
+  # All traces from a specific service, last hour
+  $ scorable otel-trace list --since 1h --service-name my_agent
+
+  # Errored traces in the last 24h, exported as CSV for spreadsheet analysis
+  $ scorable otel-trace list --since 24h --has-error --output csv > errors.csv
+
+  # All traces of a specific pydantic-ai agent on a specific model
+  $ scorable otel-trace list --agent-name my_agent --model gpt-5-mini
+
+  # Drill into traces that hit a specific tool
+  $ scorable otel-trace list --since 7d --tool fetch_customer_data
+
+  # Mix shortcuts and raw filter — they AND together
+  $ scorable otel-trace list \\
+      --service-name my_agent \\
+      --filter 'gen_ai.usage.input_tokens;number;gen_ai.usage.input_tokens;>;1000'
+
+Examples — raw --filter (when shortcuts don't fit)
+
+  # Numeric comparison (no shortcut)
+  $ scorable otel-trace list \\
+      --filter 'gen_ai.usage.input_tokens;number;gen_ai.usage.input_tokens;>;1000'
+
+  # "any of" semantics with pipe-separated values
+  $ scorable otel-trace list \\
+      --filter 'kind;stringOptions;kind;any of;3|5'
+
+  # Multi-turn debugging — every trace in a single conversation
+  $ scorable otel-trace list \\
+      --filter 'gen_ai.conversation.id;string;gen_ai.conversation.id;=;conv_5j66'
+
+  # Expensive runs — over 5k input tokens
+  $ scorable otel-trace list --since 24h \\
+      --filter 'gen_ai.usage.input_tokens;number;gen_ai.usage.input_tokens;>;5000'
+
+  # Filter by provider — e.g. only Bedrock traffic
+  $ scorable otel-trace list \\
+      --filter 'gen_ai.provider.name;string;gen_ai.provider.name;=;aws.bedrock'
+
+  # Specific time range (inclusive start, exclusive end)
+  $ scorable otel-trace list \\
+      --start-time 2026-04-30T00:00:00Z \\
+      --end-time 2026-05-01T00:00:00Z
+
+  # Pagination — pass the cursor returned in the next-page hint
+  $ scorable otel-trace list --since 7d --cursor cD0yMDI2LTA0LTMwKzEx...
+
+  # Pipe JSON to jq for ad-hoc analysis
+  $ scorable otel-trace list --since 1h --output json | jq '.results[].trace_id'`,
+    )
+    .action(
+      async (opts: {
+        filter: string[];
+        since?: string;
+        startTime?: string;
+        endTime?: string;
+        serviceName?: string;
+        hasError?: boolean;
+        rootName?: string;
+        spanName?: string;
+        agentName?: string;
+        model?: string;
+        tool?: string;
+        pageSize?: number;
+        cursor?: string;
+        output?: string;
+      }) => {
+        let format;
+        let timeFilters: string[];
+        try {
+          format = parseOutputFormat(opts.output);
+          const window = resolveTimeWindow({
+            since: opts.since,
+            startTime: opts.startTime,
+            endTime: opts.endTime,
+          });
+          timeFilters = buildTimeFilters(window);
+        } catch (e) {
+          handleSdkError(e);
+        }
+
+        const shortcutFilters: string[] = [];
+        if (opts.serviceName)
+          shortcutFilters.push(`resource;string;service.name;=;${opts.serviceName}`);
+        if (opts.hasError) shortcutFilters.push("has_error;boolean;has_error;=;true");
+        if (opts.rootName) shortcutFilters.push(`name;string;name;contains;${opts.rootName}`);
+        if (opts.spanName)
+          shortcutFilters.push(`span_name;string;span_name;contains;${opts.spanName}`);
+        if (opts.agentName)
+          shortcutFilters.push(`gen_ai.agent.name;string;gen_ai.agent.name;=;${opts.agentName}`);
+        if (opts.model)
+          shortcutFilters.push(`gen_ai.request.model;string;gen_ai.request.model;=;${opts.model}`);
+        if (opts.tool)
+          shortcutFilters.push(`gen_ai.tool.name;string;gen_ai.tool.name;=;${opts.tool}`);
+
+        const params: Record<string, unknown> = {};
+        const allFilters = [...timeFilters, ...shortcutFilters, ...opts.filter];
+        if (allFilters.length > 0) params.filters = allFilters.join(",");
+        if (opts.pageSize !== undefined) params.page_size = opts.pageSize;
+        if (opts.cursor) params.cursor = opts.cursor;
+
+        const showSpinner = format === "table";
+        const spinner = showSpinner ? ora("Fetching traces...").start() : null;
+        try {
+          const apiKey = await requireApiKey();
+          const result = (await apiRequest("GET", "v1/otel/traces", {
+            params,
+            apiKey,
+          })) as PaginatedTraces | null;
+          spinner?.stop();
+          if (!result) return;
+
+          if (format === "json") {
+            printJson(result);
+            return;
+          }
+          if (format === "csv") {
+            printTraceCsv(result.results ?? []);
+            return;
+          }
+
+          if (!result.results || result.results.length === 0) {
+            printMessage("No traces found.");
+            return;
+          }
+
+          printTraceTable(result.results);
+
+          if (result.next) {
+            const cursor = new URL(result.next).searchParams.get("cursor");
+            if (cursor) printInfo(`Next page available. Use --cursor "${cursor}"`);
+          }
+        } catch (e) {
+          spinner?.stop();
+          handleSdkError(e);
+        }
+      },
+    );
+}

--- a/cli/src/commands/otel-trace/shared.ts
+++ b/cli/src/commands/otel-trace/shared.ts
@@ -1,0 +1,94 @@
+// Shared helpers for OTEL trace commands: time-window flags, output format, CSV.
+
+export type OutputFormat = "table" | "json" | "csv";
+
+export function parseOutputFormat(value: string | undefined): OutputFormat {
+  const v = (value ?? "table").toLowerCase();
+  if (v === "table" || v === "json" || v === "csv") return v;
+  throw new Error(`Invalid --output format "${value}". Use: table, json, csv`);
+}
+
+const DURATION_PATTERN = /^(\d+(?:\.\d+)?)(ms|s|m|h|d)$/i;
+
+const UNIT_TO_MS: Record<string, number> = {
+  ms: 1,
+  s: 1000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+};
+
+// Parses durations like "30s", "5m", "1h", "7d", "1.5h". Returns milliseconds.
+export function parseDuration(input: string): number {
+  const match = DURATION_PATTERN.exec(input.trim());
+  if (!match) {
+    throw new Error(
+      `Invalid duration "${input}". Use forms like 30s, 5m, 2h, 7d (suffixes: ms, s, m, h, d).`,
+    );
+  }
+  const [, num, unit] = match;
+  return Number(num) * UNIT_TO_MS[unit.toLowerCase()];
+}
+
+// Returns ISO strings (UTC, no millis) for the resolved [start, end] window or
+// (undefined, undefined) if no time flags were given. Throws on contradiction.
+export function resolveTimeWindow(opts: { since?: string; startTime?: string; endTime?: string }): {
+  start?: string;
+  end?: string;
+} {
+  if (opts.since && (opts.startTime || opts.endTime)) {
+    throw new Error("--since cannot be combined with --start-time / --end-time.");
+  }
+
+  const end = opts.endTime ? new Date(opts.endTime) : undefined;
+  let start: Date | undefined;
+
+  if (opts.since) {
+    const ms = parseDuration(opts.since);
+    start = new Date(Date.now() - ms);
+  } else if (opts.startTime) {
+    start = new Date(opts.startTime);
+  }
+
+  if (start && Number.isNaN(start.getTime())) {
+    throw new Error(`Invalid --start-time: "${opts.startTime}".`);
+  }
+  if (end && Number.isNaN(end.getTime())) {
+    throw new Error(`Invalid --end-time: "${opts.endTime}".`);
+  }
+  if (start && end && start.getTime() >= end.getTime()) {
+    throw new Error("--start-time must be before --end-time.");
+  }
+
+  return {
+    start: start?.toISOString(),
+    end: end?.toISOString(),
+  };
+}
+
+// Build wire-format filter expressions for trace-record-level datetime columns.
+export function buildTimeFilters(window: { start?: string; end?: string }): string[] {
+  const filters: string[] = [];
+  if (window.start) {
+    filters.push(`first_span_at;datetime;first_span_at;>=;${window.start}`);
+  }
+  if (window.end) {
+    filters.push(`first_span_at;datetime;first_span_at;<;${window.end}`);
+  }
+  return filters;
+}
+
+// RFC 4180 CSV escaping: wrap in quotes if value contains comma/quote/newline,
+// double any internal quotes.
+function csvEscape(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const s = typeof value === "string" ? value : String(value);
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+export function toCsv(headers: string[], rows: unknown[][]): string {
+  const lines = [headers.map(csvEscape).join(",")];
+  for (const row of rows) lines.push(row.map(csvEscape).join(","));
+  return lines.join("\n") + "\n";
+}

--- a/cli/src/commands/otel-trace/spans.ts
+++ b/cli/src/commands/otel-trace/spans.ts
@@ -1,0 +1,164 @@
+import { Command } from "commander";
+import ora from "ora";
+import chalk from "chalk";
+import Table from "cli-table3";
+import { requireApiKey } from "../../auth.js";
+import { apiRequest } from "../../client.js";
+import { printJson, printMessage, handleSdkError } from "../../output.js";
+import { parseOutputFormat, toCsv } from "./shared.js";
+
+interface SpanRow {
+  trace_id: string;
+  span_id: string;
+  parent_span_id: string;
+  timestamp: string;
+  span: {
+    name?: string;
+    kind?: number;
+    has_error?: boolean;
+    status?: { code?: number };
+    [key: string]: unknown;
+  };
+}
+
+const UNICODE_CHARS = {
+  top: "─",
+  "top-mid": "┬",
+  "top-left": "┌",
+  "top-right": "┐",
+  bottom: "─",
+  "bottom-mid": "┴",
+  "bottom-left": "└",
+  "bottom-right": "┘",
+  left: "│",
+  "left-mid": "├",
+  mid: "─",
+  "mid-mid": "┼",
+  right: "│",
+  "right-mid": "┤",
+  middle: "│",
+};
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}
+
+function printSpanTable(spans: SpanRow[]): void {
+  const table = new Table({
+    head: ["Span ID", "Parent", "Name", "Error", "Timestamp"].map((h) => chalk.bold.cyan(h)),
+    chars: UNICODE_CHARS,
+    colWidths: [18, 18, 38, 7, 22],
+    wordWrap: true,
+  });
+
+  for (const s of spans) {
+    const ts = (s.timestamp ?? "").slice(0, 19).replace("T", " ");
+    const parent = s.parent_span_id || chalk.dim("(root)");
+    const errorMark = s.span?.has_error ? chalk.red("✖") : "";
+    table.push([s.span_id, parent, truncate(s.span?.name ?? "", 36), errorMark, ts]);
+  }
+  console.log(table.toString());
+}
+
+function printSpanCsv(spans: SpanRow[]): void {
+  const headers = [
+    "span_id",
+    "parent_span_id",
+    "name",
+    "kind",
+    "has_error",
+    "status_code",
+    "timestamp",
+  ];
+  const rows = spans.map((s) => [
+    s.span_id,
+    s.parent_span_id,
+    s.span?.name ?? "",
+    s.span?.kind ?? "",
+    s.span?.has_error ?? "",
+    s.span?.status?.code ?? "",
+    s.timestamp,
+  ]);
+  process.stdout.write(toCsv(headers, rows));
+}
+
+export function registerSpansCommand(otelTrace: Command): void {
+  otelTrace
+    .command("spans <trace_id>")
+    .description("List all spans for a given trace")
+    .option("--output <format>", "Output format: table | json | csv", "table")
+    .addHelpText(
+      "after",
+      `
+Output formats
+  table  Default. Pretty-printed columnar view: span_id, parent, name, error, timestamp.
+  json   Full payload — including attributes, events, links, status, kind, resource_attributes.
+         Use this for debugging or scripting.
+  csv    Flattened columns: span_id, parent_span_id, name, kind, has_error, status_code, timestamp.
+         Useful for spreadsheet analysis.
+
+Examples
+  # Tabular overview of all spans in a trace
+  $ scorable otel-trace spans 7b6e5bd99494c4ee46fbfd39b194c499
+
+  # Full span data for jq-piping
+  $ scorable otel-trace spans 7b6e5bd99494c4ee46fbfd39b194c499 --output json | jq '.[0].span'
+
+  # Inspect just the span attributes
+  $ scorable otel-trace spans <trace_id> --output json | \\
+      jq '.[].span | {name, attributes}'
+
+  # Pull resource attributes (e.g. service.name) from the first span
+  $ scorable otel-trace spans <trace_id> --output json | jq '.[0].span.resource_attributes'
+
+  # CSV for a quick latency / error overview
+  $ scorable otel-trace spans <trace_id> --output csv > spans.csv
+
+Tip
+  Find a trace_id first with \`scorable otel-trace list\`, then drill down here.`,
+    )
+    .action(async (traceId: string, opts: { output?: string }) => {
+      let format;
+      try {
+        format = parseOutputFormat(opts.output);
+      } catch (e) {
+        handleSdkError(e);
+      }
+
+      const showSpinner = format === "table";
+      const spinner = showSpinner ? ora(`Fetching spans for trace ${traceId}...`).start() : null;
+      try {
+        const apiKey = await requireApiKey();
+        const result = (await apiRequest(
+          "GET",
+          `v1/otel/traces/${encodeURIComponent(traceId)}/spans`,
+          { apiKey },
+        )) as SpanRow[] | null;
+        spinner?.stop();
+
+        if (result === null) return;
+        if (!Array.isArray(result)) {
+          throw new Error("Unexpected spans response: expected an array.");
+        }
+        const spans = result;
+
+        if (format === "json") {
+          printJson(spans);
+          return;
+        }
+        if (format === "csv") {
+          printSpanCsv(spans);
+          return;
+        }
+
+        if (spans.length === 0) {
+          printMessage(`No spans found for trace ${traceId}.`);
+          return;
+        }
+        printSpanTable(spans);
+      } catch (e) {
+        spinner?.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,6 +11,8 @@ import { registerExecutionLogCommands } from "./commands/execution-log/index.js"
 import { registerAuthCommands } from "./commands/auth/index.js";
 import { registerSkillsAddCommand } from "./commands/skills-add.js";
 import { registerFileCommands } from "./commands/file/index.js";
+import { registerOtelFilterCommands } from "./commands/otel-filter/index.js";
+import { registerOtelTraceCommands } from "./commands/otel-trace/index.js";
 
 const { version } = createRequire(import.meta.url)("../package.json") as {
   version: string;
@@ -70,6 +72,8 @@ export function createCli(): Command {
   registerAuthCommands(program);
   registerSkillsAddCommand(program);
   registerFileCommands(program);
+  registerOtelFilterCommands(program);
+  registerOtelTraceCommands(program);
 
   return program;
 }

--- a/cli/tests/otel-filter.test.ts
+++ b/cli/tests/otel-filter.test.ts
@@ -1,0 +1,217 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { runCli } from "./helpers/run-cli.js";
+
+const EVALUATOR_ID = "053df10f-b0c7-400b-892e-46ce3aa1e430";
+const FILTER_ID = "ae7e834e-8893-49a9-86c1-fd49299d5d9d";
+
+const sampleFilter = {
+  id: FILTER_ID,
+  name: "construction-truthfulness",
+  evaluator_id: EVALUATOR_ID,
+  judge_id: null,
+  filter_criteria: { conditions: [] },
+  sampling_rate: 1.0,
+  delay_seconds: 10,
+  applies_to_new_only: true,
+  is_active: true,
+  created_at: "2026-04-30T10:42:21Z",
+  updated_at: "2026-04-30T10:42:21Z",
+};
+
+beforeEach(() => {
+  vi.stubEnv("SCORABLE_API_KEY", "test-api-key");
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("TestOtelFilterCreate", () => {
+  it("test_create__sends_correct_payload_with_evaluator_id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve(sampleFilter),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCli([
+      "otel-filter",
+      "create",
+      "--name",
+      "construction-truthfulness",
+      "--evaluator-id",
+      EVALUATOR_ID,
+      "--filter-criteria",
+      '{"conditions":[]}',
+      "--delay-seconds",
+      "5",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/v1/otel/evaluation-filters/");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body);
+    expect(body.name).toBe("construction-truthfulness");
+    expect(body.evaluator_id).toBe(EVALUATOR_ID);
+    expect(body.judge_id).toBeUndefined();
+    expect(body.filter_criteria).toEqual({ conditions: [] });
+    expect(body.delay_seconds).toBe(5);
+    expect(body.sampling_rate).toBe(1.0);
+    expect(body.is_active).toBe(true);
+    expect(result.stdout).toContain(FILTER_ID);
+  });
+
+  it("test_create__rejects_when_neither_evaluator_nor_judge", async () => {
+    const result = await runCli(["otel-filter", "create", "--name", "x"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Either --evaluator-id or --judge-id");
+  });
+
+  it("test_create__rejects_when_both_evaluator_and_judge", async () => {
+    const result = await runCli([
+      "otel-filter",
+      "create",
+      "--name",
+      "x",
+      "--evaluator-id",
+      EVALUATOR_ID,
+      "--judge-id",
+      "00000000-0000-0000-0000-000000000000",
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("mutually exclusive");
+  });
+
+  it("test_create__rejects_invalid_filter_criteria_json", async () => {
+    const result = await runCli([
+      "otel-filter",
+      "create",
+      "--name",
+      "x",
+      "--evaluator-id",
+      EVALUATOR_ID,
+      "--filter-criteria",
+      "{not json",
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Invalid JSON");
+  });
+
+  it("test_create__rejects_sampling_rate_outside_range", async () => {
+    const result = await runCli([
+      "otel-filter",
+      "create",
+      "--name",
+      "x",
+      "--evaluator-id",
+      EVALUATOR_ID,
+      "--sampling-rate",
+      "1.5",
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("between 0.0 and 1.0");
+  });
+
+  it("test_create__rejects_negative_delay_seconds", async () => {
+    const result = await runCli([
+      "otel-filter",
+      "create",
+      "--name",
+      "x",
+      "--evaluator-id",
+      EVALUATOR_ID,
+      "--delay-seconds",
+      "-1",
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("non-negative");
+  });
+});
+
+describe("TestOtelFilterList", () => {
+  it("test_list__prints_message_when_empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([]),
+      }),
+    );
+    const result = await runCli(["otel-filter", "list"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No filters found");
+  });
+
+  it("test_list__prints_json_when_results_present", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([sampleFilter]),
+      }),
+    );
+    const result = await runCli(["otel-filter", "list"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(FILTER_ID);
+    expect(result.stdout).toContain("construction-truthfulness");
+  });
+
+  it("test_list__exits_nonzero_on_failure_and_does_not_print_empty_state", async () => {
+    // Regression: a failed request (apiRequest returns null) used to be
+    // collapsed into the "No filters found." empty-state message.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ detail: "boom" }),
+      }),
+    );
+    const result = await runCli(["otel-filter", "list"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).not.toContain("No filters found");
+  });
+});
+
+describe("TestOtelFilterDelete", () => {
+  it("test_delete__exits_nonzero_on_failure_and_does_not_print_success", async () => {
+    // Regression: previously printed "Filter X deleted." even when the request
+    // failed, because apiRequest swallows errors and returns null.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ detail: "not found" }),
+      }),
+    );
+    const result = await runCli(["otel-filter", "delete", FILTER_ID]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).not.toContain("deleted");
+  });
+
+  it("test_delete__sends_DELETE_to_correct_url", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: () => Promise.resolve(null),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCli(["otel-filter", "delete", FILTER_ID]);
+
+    expect(result.exitCode).toBe(0);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain(`/v1/otel/evaluation-filters/${FILTER_ID}`);
+    expect(init.method).toBe("DELETE");
+    expect(result.stdout).toContain("deleted");
+  });
+});

--- a/cli/tests/otel-filter.test.ts
+++ b/cli/tests/otel-filter.test.ts
@@ -66,6 +66,33 @@ describe("TestOtelFilterCreate", () => {
     expect(result.stdout).toContain(FILTER_ID);
   });
 
+  it("test_create__sends_correct_payload_with_judge_id", async () => {
+    const JUDGE_ID = "11111111-1111-1111-1111-111111111111";
+    const judgeFilter = { ...sampleFilter, evaluator_id: null, judge_id: JUDGE_ID };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve(judgeFilter),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCli([
+      "otel-filter",
+      "create",
+      "--name",
+      "construction-judge",
+      "--judge-id",
+      JUDGE_ID,
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.judge_id).toBe(JUDGE_ID);
+    expect(body.evaluator_id).toBeUndefined();
+    expect(result.stdout).toContain(JUDGE_ID);
+  });
+
   it("test_create__rejects_when_neither_evaluator_nor_judge", async () => {
     const result = await runCli(["otel-filter", "create", "--name", "x"]);
     expect(result.exitCode).toBe(1);

--- a/cli/tests/otel-trace.test.ts
+++ b/cli/tests/otel-trace.test.ts
@@ -1,0 +1,398 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { runCli } from "./helpers/run-cli.js";
+import {
+  buildTimeFilters,
+  parseDuration,
+  parseOutputFormat,
+  resolveTimeWindow,
+  toCsv,
+} from "../src/commands/otel-trace/shared.js";
+
+const TRACE_ID = "7b6e5bd99494c4ee46fbfd39b194c499";
+const SPAN_ID = "9fce49e165608b93";
+
+const sampleTrace = {
+  trace_id: TRACE_ID,
+  root_span_name: "construction_assistant_agent run",
+  first_span_at: "2026-04-30T11:12:12Z",
+  last_span_at: "2026-04-30T11:12:15Z",
+  span_count: 4,
+  input_preview: "Question, with comma",
+  output_preview: 'Answer with "quotes"',
+};
+
+const sampleSpan = {
+  trace_id: TRACE_ID,
+  span_id: SPAN_ID,
+  parent_span_id: "",
+  timestamp: "2026-04-30T11:12:12Z",
+  span: {
+    name: "construction_assistant_agent run",
+    kind: 1,
+    has_error: false,
+    status: { code: 0 },
+    attributes: [],
+    resource_attributes: [{ key: "service.name", value: { stringValue: "construction" } }],
+  },
+};
+
+beforeEach(() => {
+  vi.stubEnv("SCORABLE_API_KEY", "test-api-key");
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("TestSharedHelpers", () => {
+  describe("parseDuration", () => {
+    it("parses common forms", () => {
+      expect(parseDuration("30s")).toBe(30_000);
+      expect(parseDuration("5m")).toBe(5 * 60_000);
+      expect(parseDuration("2h")).toBe(2 * 3_600_000);
+      expect(parseDuration("7d")).toBe(7 * 86_400_000);
+      expect(parseDuration("100ms")).toBe(100);
+      expect(parseDuration("1.5h")).toBe(1.5 * 3_600_000);
+    });
+
+    it("rejects invalid forms", () => {
+      expect(() => parseDuration("bogus")).toThrow(/Invalid duration/);
+      expect(() => parseDuration("5")).toThrow(/Invalid duration/);
+      expect(() => parseDuration("hour")).toThrow(/Invalid duration/);
+    });
+  });
+
+  describe("resolveTimeWindow", () => {
+    it("returns empty when no flags given", () => {
+      const w = resolveTimeWindow({});
+      expect(w.start).toBeUndefined();
+      expect(w.end).toBeUndefined();
+    });
+
+    it("computes start from --since", () => {
+      const before = Date.now();
+      const w = resolveTimeWindow({ since: "1h" });
+      const after = Date.now();
+      const start = new Date(w.start!).getTime();
+      expect(start).toBeGreaterThanOrEqual(before - 3_600_000);
+      expect(start).toBeLessThanOrEqual(after - 3_600_000 + 100);
+    });
+
+    it("rejects --since combined with --start-time/--end-time", () => {
+      expect(() => resolveTimeWindow({ since: "1h", startTime: "2026-01-01T00:00:00Z" })).toThrow(
+        /cannot be combined/,
+      );
+      expect(() => resolveTimeWindow({ since: "1h", endTime: "2026-01-01T00:00:00Z" })).toThrow(
+        /cannot be combined/,
+      );
+    });
+
+    it("rejects invalid ISO timestamps", () => {
+      expect(() => resolveTimeWindow({ startTime: "not-a-date" })).toThrow(/Invalid --start-time/);
+      expect(() => resolveTimeWindow({ endTime: "not-a-date" })).toThrow(/Invalid --end-time/);
+    });
+
+    it("rejects start >= end", () => {
+      expect(() =>
+        resolveTimeWindow({
+          startTime: "2026-05-01T00:00:00Z",
+          endTime: "2026-04-01T00:00:00Z",
+        }),
+      ).toThrow(/before --end-time/);
+    });
+  });
+
+  describe("buildTimeFilters", () => {
+    it("returns empty list when no window", () => {
+      expect(buildTimeFilters({})).toEqual([]);
+    });
+
+    it("compiles to wire-format expressions", () => {
+      const filters = buildTimeFilters({
+        start: "2026-04-30T00:00:00Z",
+        end: "2026-05-01T00:00:00Z",
+      });
+      expect(filters).toEqual([
+        "first_span_at;datetime;first_span_at;>=;2026-04-30T00:00:00Z",
+        "first_span_at;datetime;first_span_at;<;2026-05-01T00:00:00Z",
+      ]);
+    });
+  });
+
+  describe("parseOutputFormat", () => {
+    it("accepts table, json, csv", () => {
+      expect(parseOutputFormat("table")).toBe("table");
+      expect(parseOutputFormat("json")).toBe("json");
+      expect(parseOutputFormat("csv")).toBe("csv");
+    });
+
+    it("defaults to table", () => {
+      expect(parseOutputFormat(undefined)).toBe("table");
+    });
+
+    it("rejects unknown formats", () => {
+      expect(() => parseOutputFormat("yaml")).toThrow(/Invalid --output/);
+    });
+  });
+
+  describe("toCsv", () => {
+    it("renders simple rows", () => {
+      const out = toCsv(
+        ["a", "b"],
+        [
+          ["1", "2"],
+          ["3", "4"],
+        ],
+      );
+      expect(out).toBe("a,b\n1,2\n3,4\n");
+    });
+
+    it("RFC 4180 quotes commas, quotes, and newlines", () => {
+      const out = toCsv(["x"], [["has,comma"], ['has"quote'], ["has\nnewline"]]);
+      expect(out).toBe('x\n"has,comma"\n"has""quote"\n"has\nnewline"\n');
+    });
+
+    it("handles null and numeric values", () => {
+      const out = toCsv(["a", "b"], [[null, 42]]);
+      expect(out).toBe("a,b\n,42\n");
+    });
+  });
+});
+
+describe("TestOtelTraceList", () => {
+  function fetchOk(payload: unknown) {
+    return vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(payload),
+    });
+  }
+
+  function getRequestUrl(fetchMock: ReturnType<typeof vi.fn>): URL {
+    return new URL(String(fetchMock.mock.calls[0][0]));
+  }
+
+  function getFiltersParam(fetchMock: ReturnType<typeof vi.fn>): string {
+    return getRequestUrl(fetchMock).searchParams.get("filters") ?? "";
+  }
+
+  it("test_list__no_filters_omits_filters_param", async () => {
+    const fetchMock = fetchOk({ next: null, previous: null, results: [sampleTrace] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCli(["otel-trace", "list"]);
+    expect(result.exitCode).toBe(0);
+    const url = getRequestUrl(fetchMock);
+    expect(url.pathname).toContain("/v1/otel/traces/");
+    expect(url.searchParams.has("filters")).toBe(false);
+  });
+
+  it("test_list__service_name_shortcut_compiles_to_resource_sentinel", async () => {
+    const fetchMock = fetchOk({ next: null, previous: null, results: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runCli(["otel-trace", "list", "--service-name", "my_agent"]);
+    expect(getFiltersParam(fetchMock)).toBe("resource;string;service.name;=;my_agent");
+  });
+
+  it("test_list__has_error_shortcut_compiles_to_boolean_filter", async () => {
+    const fetchMock = fetchOk({ next: null, previous: null, results: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runCli(["otel-trace", "list", "--has-error"]);
+    expect(getFiltersParam(fetchMock)).toBe("has_error;boolean;has_error;=;true");
+  });
+
+  it("test_list__multiple_shortcuts_AND_combine", async () => {
+    const fetchMock = fetchOk({ next: null, previous: null, results: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runCli([
+      "otel-trace",
+      "list",
+      "--service-name",
+      "my_agent",
+      "--has-error",
+      "--tool",
+      "fetch_customer_data",
+    ]);
+    const filters = getFiltersParam(fetchMock).split(",");
+    expect(filters).toContain("resource;string;service.name;=;my_agent");
+    expect(filters).toContain("has_error;boolean;has_error;=;true");
+    expect(filters).toContain("gen_ai.tool.name;string;gen_ai.tool.name;=;fetch_customer_data");
+  });
+
+  it("test_list__since_adds_first_span_at_filter", async () => {
+    const fetchMock = fetchOk({ next: null, previous: null, results: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runCli(["otel-trace", "list", "--since", "1h"]);
+    const filters = getFiltersParam(fetchMock).split(",");
+    expect(filters[0]).toMatch(/^first_span_at;datetime;first_span_at;>=;\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("test_list__shortcut_AND_raw_filter_combine", async () => {
+    const fetchMock = fetchOk({ next: null, previous: null, results: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runCli([
+      "otel-trace",
+      "list",
+      "--service-name",
+      "my_agent",
+      "--filter",
+      "gen_ai.usage.input_tokens;number;gen_ai.usage.input_tokens;>;1000",
+    ]);
+    const filters = getFiltersParam(fetchMock).split(",");
+    expect(filters).toContain("resource;string;service.name;=;my_agent");
+    expect(filters).toContain("gen_ai.usage.input_tokens;number;gen_ai.usage.input_tokens;>;1000");
+  });
+
+  it("test_list__output_csv_emits_header_and_rfc4180_quoted_rows", async () => {
+    vi.stubGlobal("fetch", fetchOk({ next: null, previous: null, results: [sampleTrace] }));
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const result = await runCli(["otel-trace", "list", "--output", "csv"]);
+      expect(result.exitCode).toBe(0);
+      const csv = writeSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(csv).toContain("trace_id,root_span_name,span_count");
+      expect(csv).toContain(TRACE_ID);
+      // Comma in the input_preview value must be quoted.
+      expect(csv).toContain('"Question, with comma"');
+      // Quotes in the output_preview value must be doubled.
+      expect(csv).toContain('"Answer with ""quotes"""');
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it("test_list__output_json_emits_full_payload", async () => {
+    vi.stubGlobal("fetch", fetchOk({ next: null, previous: null, results: [sampleTrace] }));
+
+    const result = await runCli(["otel-trace", "list", "--output", "json"]);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.results[0].trace_id).toBe(TRACE_ID);
+  });
+
+  it("test_list__rejects_invalid_output_format", async () => {
+    const result = await runCli(["otel-trace", "list", "--output", "yaml"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Invalid --output");
+  });
+
+  it("test_list__rejects_since_combined_with_start_time", async () => {
+    const result = await runCli([
+      "otel-trace",
+      "list",
+      "--since",
+      "1h",
+      "--start-time",
+      "2026-01-01T00:00:00Z",
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("cannot be combined");
+  });
+
+  it("test_list__rejects_invalid_since_duration", async () => {
+    const result = await runCli(["otel-trace", "list", "--since", "tomorrow"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Invalid duration");
+  });
+
+  it("test_list__cursor_passes_through", async () => {
+    const fetchMock = fetchOk({ next: null, previous: null, results: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runCli(["otel-trace", "list", "--cursor", "abc123"]);
+    expect(getRequestUrl(fetchMock).searchParams.get("cursor")).toBe("abc123");
+  });
+
+  it("test_list__surfaces_next_cursor_hint", async () => {
+    const fetchMock = fetchOk({
+      next: "http://localhost/v1/otel/traces/?cursor=NEXT123&page_size=25",
+      previous: null,
+      results: [sampleTrace],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCli(["otel-trace", "list"]);
+    expect(result.stdout).toContain('--cursor "NEXT123"');
+  });
+});
+
+describe("TestOtelTraceSpans", () => {
+  function fetchOk(payload: unknown) {
+    return vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(payload),
+    });
+  }
+
+  it("test_spans__hits_correct_endpoint", async () => {
+    const fetchMock = fetchOk([sampleSpan]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCli(["otel-trace", "spans", TRACE_ID]);
+    expect(result.exitCode).toBe(0);
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain(`/v1/otel/traces/${TRACE_ID}/spans`);
+  });
+
+  it("test_spans__output_json_returns_full_payload", async () => {
+    vi.stubGlobal("fetch", fetchOk([sampleSpan]));
+    const result = await runCli(["otel-trace", "spans", TRACE_ID, "--output", "json"]);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed[0].span_id).toBe(SPAN_ID);
+    expect(parsed[0].span.resource_attributes).toBeDefined();
+  });
+
+  it("test_spans__output_csv_emits_flattened_columns", async () => {
+    vi.stubGlobal("fetch", fetchOk([sampleSpan]));
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const result = await runCli(["otel-trace", "spans", TRACE_ID, "--output", "csv"]);
+      expect(result.exitCode).toBe(0);
+      const csv = writeSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(csv).toContain("span_id,parent_span_id,name,kind,has_error,status_code,timestamp");
+      expect(csv).toContain(SPAN_ID);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it("test_spans__empty_result_prints_message", async () => {
+    vi.stubGlobal("fetch", fetchOk([]));
+    const result = await runCli(["otel-trace", "spans", TRACE_ID]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No spans found");
+  });
+
+  it("test_spans__url_encodes_trace_id", async () => {
+    // Regression: a trace_id with /, ?, # used to break the request path.
+    const fetchMock = fetchOk([]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const messy = "abc/def?x#y";
+    await runCli(["otel-trace", "spans", messy]);
+
+    const requested = String(fetchMock.mock.calls[0][0]);
+    expect(requested).toContain(encodeURIComponent(messy));
+    // Should not contain the raw `/` from the input (only path separators stay).
+    expect(requested.split("/v1/otel/traces/")[1]).not.toContain("/def");
+  });
+
+  it("test_spans__rejects_non_array_response", async () => {
+    // Regression: a {} response used to be silently coerced to [].
+    vi.stubGlobal("fetch", fetchOk({ unexpected: "shape" }));
+    const result = await runCli(["otel-trace", "spans", TRACE_ID]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Unexpected spans response");
+  });
+});


### PR DESCRIPTION
## Summary

Two new top-level CLI command groups for Scorable's OTEL ingestion and evaluation pipeline:

- **`scorable otel-filter`** — CRUD on trace evaluation filters (server-side rules that auto-run an evaluator/judge against incoming traces).
- **`scorable otel-trace`** — query traces and drill into spans.

Backed by raw \`apiRequest\` while the SDK schema regen catches up to the public \`/v1/otel/*\` endpoints; trivial to swap to typed SDK calls later.

## What's in the box

\`scorable otel-filter\`:
- \`create\` — wire an evaluator or judge to incoming traces (\`filter_criteria\`, \`sampling_rate\`, \`delay_seconds\`, \`applies_to_new_only\`). Uses the \`column: "resource"\` sentinel for resource attributes — no leaked prefixes.
- \`list\` / \`delete\` — straightforward.

\`scorable otel-trace list\` exposes filtering in three layers, documented inline in \`--help\`:

1. **Convenience flags** (covers ~80% of queries): \`--service-name\`, \`--has-error\`, \`--root-name\`, \`--span-name\`, \`--agent-name\`, \`--model\`, \`--tool\` — all compile to wire form and AND-combine.
2. **Time-window flags**: \`--since 30s|5m|2h|7d\` or \`--start-time\`/\`--end-time\` (ISO 8601), mutually exclusive with \`--since\`.
3. **Raw \`--filter\`**: \`column;type;key;operator;value\`, repeatable. Documented as the full-power escape hatch.

Output: \`--output table | json | csv\`. CSV uses RFC 4180 quoting so embedded commas/quotes/newlines survive. Spinner is suppressed for \`json\`/\`csv\` so output stays clean for piping.

\`scorable otel-trace spans <trace_id>\` dumps all spans for a trace in the same three formats. JSON form returns the full payload (attributes, events, status, kind, \`resource_attributes\`) for jq piping.

## Backend dependencies

Requires the matching backend changes on the api side (\`feat/otel-public-api\` branch in the monorepo) — public \`/v1/otel/*\` endpoints with trailing-slash convention, resource-attribute filter sentinel, ingestion flattening with \`resource.\` prefix.

## Test plan

- [x] \`npm run check-all\` (typecheck + lint + fmt:check + 115 tests) passes
- [x] Live e2e against local API:
  - \`otel-filter create --filter-criteria '{"conditions":[{"column":"resource",...}]}'\` creates a filter, traces from a matching service trigger eval
  - \`otel-trace list --since 24h --service-name X\` returns expected trace
  - \`otel-trace list --since 24h --has-error --output csv > errors.csv\` produces valid CSV with proper quoting
  - \`otel-trace spans <id> --output json | jq\` works for inspection
- [ ] Manual smoke against staging once the API branch is merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added otel-filter commands to create, list, and delete evaluation filters with validation, sampling/delay/activation options, JSON criteria support, and clear success/error messages.
  * Added otel-trace commands to list traces and view spans with flexible time-window parsing, layered filtering, pagination, and table/JSON/CSV output (robust CSV quoting and output-format validation).

* **Tests**
  * Added end-to-end tests covering otel-filter and otel-trace behavior, validation, pagination, and output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->