### PR TITLE
Release CLI v0.8.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.8.0
+
+- Add `scorable otel-filter` command group for managing OTEL trace evaluation filters (`create`, `list`, `delete`). Wires an evaluator (`--evaluator-id`) or judge (`--judge-id`) to incoming traces; filters auto-run against matching traces and the result lands back on the trace as a child span carrying the OpenTelemetry GenAI evaluation attributes.
+- Add `scorable otel-trace` command group for querying ingested traces: `list` (with time-window, convenience flags, and raw filter expressions) and `spans <trace_id>` for drilling into one trace.
+- `otel-trace list` convenience flags: `--service-name`, `--has-error`, `--root-name`, `--span-name`, `--agent-name`, `--model`, `--tool`. Each compiles to a wire-format filter and AND-combines with the others and with `--filter`.
+- Time-window flags: `--since 30s|5m|2h|7d`, or `--start-time` and `--end-time` (ISO 8601, mutually exclusive with `--since`).
+- Output formats for `otel-trace list` and `otel-trace spans`: `--output table | json | csv`. CSV uses RFC 4180 quoting so embedded commas, quotes, and newlines round-trip safely.
+
 ## 0.7.0
 
 - Add `scorable file upload <path>` command to upload files (PDF, PNG, JPG, JPEG, WEBP, SVG)

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@root-signals/scorable-cli",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",


### PR DESCRIPTION
## CLI v0.8.0

- Add \`scorable otel-filter\` command group for managing OTEL trace evaluation filters (\`create\`, \`list\`, \`delete\`). Wires an evaluator (\`--evaluator-id\`) or judge (\`--judge-id\`) to incoming traces; filters auto-run against matching traces and the result lands back on the trace as a child span carrying the OpenTelemetry GenAI evaluation attributes.
- Add \`scorable otel-trace\` command group for querying ingested traces: \`list\` (with time-window, convenience flags, and raw filter expressions) and \`spans <trace_id>\` for drilling into one trace.
- \`otel-trace list\` convenience flags: \`--service-name\`, \`--has-error\`, \`--root-name\`, \`--span-name\`, \`--agent-name\`, \`--model\`, \`--tool\`. Each compiles to a wire-format filter and AND-combines with the others and with \`--filter\`.
- Time-window flags: \`--since 30s|5m|2h|7d\`, or \`--start-time\` and \`--end-time\` (ISO 8601, mutually exclusive with \`--since\`).
- Output formats for \`otel-trace list\` and \`otel-trace spans\`: \`--output table | json | csv\`. CSV uses RFC 4180 quoting so embedded commas, quotes, and newlines round-trip safely.

The features themselves landed in #114; this PR carries the version bump and CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `scorable otel-filter` command group for creating, listing, and deleting OTEL trace evaluation filters
  * Added `scorable otel-trace` command group for listing traces and inspecting spans
  * Added convenience filtering flags for trace listing
  * Added time-window selection flags (`--since`, `--start-time`, `--end-time`)
  * Added multiple output format options: table, JSON, and CSV

<!-- end of auto-generated comment: release notes by coderabbit.ai -->