### PR TITLE
feat(cli): otel-filter YAML manifests with extractor rules

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -423,6 +423,24 @@ evaluators:
 
 Results are displayed in a table and a browser link is printed for the full comparison view.
 
+### OTEL evaluation filters
+
+Filters describe which OTEL traces to evaluate and where the input/output content lives in their spans. Persist them as YAML files and apply with the CLI:
+
+```bash
+scorable otel-filter create -f filter.yaml
+scorable otel-filter update <id> -f filter.yaml
+scorable otel-filter validate -f filter.yaml
+```
+
+Three reference manifests in `examples/otel-filters/`:
+
+- `openinference-agent.yaml` — single-span agent emitting OpenInference `input.value` / `output.value` attributes.
+- `claude-code.yaml` — Claude Code's interaction span (user prompt) plus tool spans (input/output events).
+- `genai-explicit.yaml` — gen_ai messages with custom attribute keys.
+
+Filters with no `extractor_rules` fall back to the built-in `gen_ai.input.messages` / `gen_ai.output.messages` extractor.
+
 ## Development
 
 ```bash

--- a/cli/README.md
+++ b/cli/README.md
@@ -302,6 +302,110 @@ scorable otel-filter list
 scorable otel-filter delete <filter_id>
 ```
 
+### Custom extractor rules (when input/output isn't in `gen_ai.*`)
+
+For the common case the flags above are everything you need: matching traces are evaluated and their `gen_ai.input.messages` / `gen_ai.output.messages` are fed to the evaluator. If your traces don't follow that shape — Claude Code, OpenInference, custom instrumentations — you tell the evaluator where input/output live by attaching **`extractor_rules`** to the filter. Filters without `extractor_rules` keep the default behavior.
+
+Rules are carried in a YAML manifest and applied with `-f`:
+
+```bash
+scorable otel-filter create -f filter.yaml
+scorable otel-filter update <id> -f filter.yaml
+scorable otel-filter validate -f filter.yaml   # dry-run; exit 2 on schema error
+```
+
+CLI flags override values from the file when both are provided.
+
+#### Manifest shape
+
+```yaml
+name: <string>
+evaluator_id: <uuid> # exactly one of evaluator_id / judge_id
+judge_id: <uuid>
+sampling_rate: <0.0-1.0> # optional, default 1.0
+delay_seconds: <int> # optional, default 10
+is_active: <bool> # optional, default true
+filter_criteria: # which traces to evaluate (same shape as --filter-criteria)
+  conditions:
+    - column: <string> # span_name, has_error, kind, status, attribute, resource, …
+      operator: <string> # =, !=, contains, starts with, any of, none of, …
+      value: <string|number|bool>
+      key: <string> # required for "attribute" / "resource" sentinel columns
+extractor_rules: # optional; how to extract input/output from matching spans
+  - emit: <text|request_response|tool_pair|genai_messages>
+    match: # optional; same shape as filter_criteria — empty matches every span
+      conditions: [...]
+    # … emit-specific fields, see below …
+```
+
+#### `extractor_rules` reference
+
+Each rule has an `emit` kind, an optional `match` filter (same shape as `filter_criteria.conditions`), and emit-specific fields. Spans are walked in timestamp order; per span, the **first** rule whose `match` passes wins.
+
+A rule set must be able to produce both user-side and agent-side content (a `request_response` or `genai_messages` rule alone qualifies; a single `text` `role: user` rule does not). Validation rejects sets that can't.
+
+**`text`** — emit one `MessageTurn` per matching span.
+
+```yaml
+- emit: text
+  match: # optional
+    conditions:
+      - { column: span_name, operator: "=", value: claude_code.interaction }
+  role: user # user | assistant
+  locator: # where the value lives
+    kind: span_attr # span_attr | event_attr | resource_attr
+    key: user_prompt # attribute name
+    event_name: <string> # required when kind: event_attr
+    value_path: $.foo # optional JSONPath into the located value
+  tool_name: <string> # only valid when role: assistant
+```
+
+**`request_response`** — emit a user turn + an assistant turn from one span. Common when an agent stores prompt and response as flat attributes (OpenInference's `input.value` / `output.value`).
+
+```yaml
+- emit: request_response
+  match: { ... } # optional
+  input_locator: { kind: span_attr, key: input.value } # → user turn
+  output_locator: { kind: span_attr, key: output.value } # → assistant turn
+```
+
+**`tool_pair`** — emit one assistant turn per matching span carrying a tool call (input + output combined into the turn content). Built for tool-execution spans like Claude Code's `claude_code.tool` event.
+
+```yaml
+- emit: tool_pair
+  match: { ... } # optional
+  input_locator: { kind: event_attr, event_name: tool.output, key: bash_command }
+  output_locator: { kind: event_attr, event_name: tool.output, key: output }
+  tool_name: Bash # static; OR
+  tool_name_locator: { kind: span_attr, key: tool_name } # dynamic
+```
+
+**`genai_messages`** — same parsing as the default extractor, but on attribute keys you choose. Use this if your service emits the standard `gen_ai` JSON-array shape under non-default attribute names.
+
+```yaml
+- emit: genai_messages
+  match: { ... } # optional
+  input_locator: { kind: span_attr, key: my_framework.input.json }
+  output_locator: { kind: span_attr, key: my_framework.output.json }
+```
+
+#### Locator details
+
+| Field        | Meaning                                                                                           |
+| ------------ | ------------------------------------------------------------------------------------------------- |
+| `kind`       | `span_attr` (top-level), `event_attr` (inside a named event), or `resource_attr` (resource-level) |
+| `key`        | Attribute name to read                                                                            |
+| `event_name` | Only for `event_attr` — the OTel event whose attributes to read (e.g. `tool.output`)              |
+| `value_path` | Optional JSONPath into the located value; used when the attribute is itself JSON                  |
+
+#### Reference manifests
+
+`examples/otel-filters/`:
+
+- `openinference-agent.yaml` — single-span agent with `input.value` / `output.value` (`request_response`).
+- `claude-code.yaml` — Claude Code's interaction span + tool spans (`text` + `tool_pair`).
+- `genai-explicit.yaml` — gen_ai messages under custom attribute keys.
+
 ## OTEL Trace Querying
 
 ### List traces
@@ -422,24 +526,6 @@ evaluators:
 ```
 
 Results are displayed in a table and a browser link is printed for the full comparison view.
-
-### OTEL evaluation filters
-
-Filters describe which OTEL traces to evaluate and where the input/output content lives in their spans. Persist them as YAML files and apply with the CLI:
-
-```bash
-scorable otel-filter create -f filter.yaml
-scorable otel-filter update <id> -f filter.yaml
-scorable otel-filter validate -f filter.yaml
-```
-
-Three reference manifests in `examples/otel-filters/`:
-
-- `openinference-agent.yaml` — single-span agent emitting OpenInference `input.value` / `output.value` attributes.
-- `claude-code.yaml` — Claude Code's interaction span (user prompt) plus tool spans (input/output events).
-- `genai-explicit.yaml` — gen_ai messages with custom attribute keys.
-
-Filters with no `extractor_rules` fall back to the built-in `gen_ai.input.messages` / `gen_ai.output.messages` extractor.
 
 ## Development
 

--- a/cli/examples/otel-filters/claude-code.yaml
+++ b/cli/examples/otel-filters/claude-code.yaml
@@ -1,0 +1,23 @@
+name: claude-code-conversation-eval
+judge_id: 0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91
+sampling_rate: 1.0
+delay_seconds: 60
+is_active: true
+
+filter_criteria:
+  conditions:
+    - column: span_name
+      operator: starts_with
+      value: claude_code.
+
+extractor_rules:
+  - emit: text
+    match: { span_name: { eq: claude_code.interaction } }
+    role: user
+    locator: { kind: span_attr, key: user_prompt }
+
+  - emit: tool_pair
+    match: { span_name: { eq: claude_code.tool } }
+    tool_name: Bash
+    input_locator: { kind: event_attr, event_name: tool.output, key: bash_command }
+    output_locator: { kind: event_attr, event_name: tool.output, key: output }

--- a/cli/examples/otel-filters/claude-code.yaml
+++ b/cli/examples/otel-filters/claude-code.yaml
@@ -12,12 +12,20 @@ filter_criteria:
 
 extractor_rules:
   - emit: text
-    match: { span_name: { eq: claude_code.interaction } }
+    match:
+      conditions:
+        - column: span_name
+          operator: "="
+          value: claude_code.interaction
     role: user
     locator: { kind: span_attr, key: user_prompt }
 
   - emit: tool_pair
-    match: { span_name: { eq: claude_code.tool } }
+    match:
+      conditions:
+        - column: span_name
+          operator: "="
+          value: claude_code.tool
     tool_name: Bash
     input_locator: { kind: event_attr, event_name: tool.output, key: bash_command }
     output_locator: { kind: event_attr, event_name: tool.output, key: output }

--- a/cli/examples/otel-filters/genai-explicit.yaml
+++ b/cli/examples/otel-filters/genai-explicit.yaml
@@ -1,0 +1,16 @@
+name: custom-genai-keys-eval
+judge_id: 0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91
+sampling_rate: 1.0
+delay_seconds: 60
+is_active: true
+
+filter_criteria:
+  conditions:
+    - column: span_name
+      operator: starts_with
+      value: my_framework.
+
+extractor_rules:
+  - emit: genai_messages
+    input_locator: { kind: span_attr, key: my_framework.input.json }
+    output_locator: { kind: span_attr, key: my_framework.output.json }

--- a/cli/examples/otel-filters/openinference-agent.yaml
+++ b/cli/examples/otel-filters/openinference-agent.yaml
@@ -1,0 +1,17 @@
+name: openinference-agent-eval
+judge_id: 0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91
+sampling_rate: 1.0
+delay_seconds: 60
+is_active: true
+
+filter_criteria:
+  conditions:
+    - column: attribute
+      key: openinference.span.kind
+      operator: eq
+      value: AGENT
+
+extractor_rules:
+  - emit: request_response
+    input_locator: { kind: span_attr, key: input.value }
+    output_locator: { kind: span_attr, key: output.value }

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -15,7 +15,8 @@
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
         "js-yaml": "^4.1.1",
-        "ora": "^9.3.0"
+        "ora": "^9.3.0",
+        "zod": "^4.4.3"
       },
       "bin": {
         "scorable": "dist/index.js",
@@ -3113,6 +3114,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/cli/package.json
+++ b/cli/package.json
@@ -13,6 +13,7 @@
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "dist/**/*.d.ts.map",
+    "examples/**/*.yaml",
     "README.md",
     "LICENSE"
   ],

--- a/cli/package.json
+++ b/cli/package.json
@@ -36,7 +36,8 @@
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",
     "js-yaml": "^4.1.1",
-    "ora": "^9.3.0"
+    "ora": "^9.3.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/cli/src/commands/otel-filter/create.ts
+++ b/cli/src/commands/otel-filter/create.ts
@@ -1,17 +1,20 @@
+import fs from "node:fs";
 import { Command } from "commander";
 import ora from "ora";
 import { requireApiKey } from "../../auth.js";
 import { apiRequest } from "../../client.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
+import { loadFilterYaml } from "../../lib/filter-yaml.js";
 
 interface CreateOptions {
-  name: string;
+  name?: string;
   evaluatorId?: string;
   judgeId?: string;
   filterCriteria?: string;
   samplingRate?: string;
   delaySeconds?: string;
   inactive?: boolean;
+  fromFile?: string;
 }
 
 export function registerCreateCommand(otelFilter: Command): void {
@@ -20,7 +23,7 @@ export function registerCreateCommand(otelFilter: Command): void {
     .description(
       "Create a new OTEL trace evaluation filter. Wires either an evaluator OR a judge to incoming traces.",
     )
-    .requiredOption("--name <name>", "Filter name")
+    .option("--name <name>", "Filter name")
     .option(
       "--evaluator-id <id>",
       "Evaluator UUID to run on matching traces (mutually exclusive with --judge-id)",
@@ -33,13 +36,17 @@ export function registerCreateCommand(otelFilter: Command): void {
       "--filter-criteria <json>",
       'Filter conditions as JSON, e.g. \'{"conditions":[{"column":"name","type":"string","key":"name","operator":"contains","value":"agent"}]}\'',
     )
-    .option("--sampling-rate <rate>", "Sampling rate between 0.0 and 1.0", "1.0")
-    .option("--delay-seconds <seconds>", "Delay before evaluation (allows late spans)", "10")
-    .option("--inactive", "Create the filter as inactive", false)
+    .option("--sampling-rate <rate>", "Sampling rate between 0.0 and 1.0")
+    .option("--delay-seconds <seconds>", "Delay before evaluation (allows late spans)")
+    .option("--inactive", "Create the filter as inactive")
+    .option(
+      "-f, --from-file <path>",
+      "Load filter spec from a YAML or JSON file. CLI flags override file values.",
+    )
     .addHelpText(
       "after",
       `
-Target — exactly one of --evaluator-id or --judge-id is required.
+Target — exactly one of --evaluator-id or --judge-id is required (either via flags or --from-file).
   --evaluator-id  Runs a single evaluator (one score, one justification).
   --judge-id      Runs a judge — a bundle of evaluators that produces an
                   aggregate verdict plus per-evaluator scores. Use this
@@ -59,30 +66,30 @@ Examples:
       --filter-criteria '{"conditions":[{"column":"resource","type":"string","key":"service.name","operator":"=","value":"construction_assistant_agent"}]}' \\
       --delay-seconds 5
 
-  # Match only traces from a specific service (resource attribute), evaluator target
-  $ scorable otel-filter create \\
-      --name "construction-truthfulness" \\
-      --evaluator-id <evaluator-uuid> \\
-      --filter-criteria '{"conditions":[{"column":"resource","type":"string","key":"service.name","operator":"=","value":"construction_assistant_agent"}]}' \\
-      --delay-seconds 5
-
-  # Match by span attribute (gen_ai semantic conventions)
-  $ scorable otel-filter create \\
-      --name "agent-truthfulness" \\
-      --evaluator-id <evaluator-uuid> \\
-      --filter-criteria '{"conditions":[{"column":"gen_ai.agent.name","type":"string","key":"gen_ai.agent.name","operator":"=","value":"my_agent"}]}'`,
+  # Load the full filter spec (including extractor_rules) from a YAML file
+  $ scorable otel-filter create -f ./filter.yaml`,
     )
     .action(async (opts: CreateOptions) => {
-      if (!opts.evaluatorId && !opts.judgeId) {
-        printError("Either --evaluator-id or --judge-id is required.");
-        process.exit(1);
-      }
-      if (opts.evaluatorId && opts.judgeId) {
-        printError("--evaluator-id and --judge-id are mutually exclusive.");
-        process.exit(1);
+      let filePayload: Record<string, unknown> = {};
+      if (opts.fromFile) {
+        let source: string;
+        try {
+          source = fs.readFileSync(opts.fromFile, "utf8");
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          printError(`Failed to read --from-file: ${msg}`);
+          process.exit(1);
+        }
+        try {
+          filePayload = loadFilterYaml(source) as unknown as Record<string, unknown>;
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          printError(msg);
+          process.exit(1);
+        }
       }
 
-      let filterCriteria: Record<string, unknown> = {};
+      let filterCriteria: Record<string, unknown> | undefined;
       if (opts.filterCriteria) {
         try {
           filterCriteria = JSON.parse(opts.filterCriteria) as Record<string, unknown>;
@@ -92,27 +99,54 @@ Examples:
         }
       }
 
-      const samplingRate = parseFloat(opts.samplingRate ?? "1.0");
-      if (Number.isNaN(samplingRate) || samplingRate < 0 || samplingRate > 1) {
-        printError("--sampling-rate must be a number between 0.0 and 1.0.");
-        process.exit(1);
+      let samplingRate: number | undefined;
+      if (opts.samplingRate !== undefined) {
+        samplingRate = parseFloat(opts.samplingRate);
+        if (Number.isNaN(samplingRate) || samplingRate < 0 || samplingRate > 1) {
+          printError("--sampling-rate must be a number between 0.0 and 1.0.");
+          process.exit(1);
+        }
       }
 
-      const delaySeconds = parseInt(opts.delaySeconds ?? "10", 10);
-      if (Number.isNaN(delaySeconds) || delaySeconds < 0) {
-        printError("--delay-seconds must be a non-negative integer.");
-        process.exit(1);
+      let delaySeconds: number | undefined;
+      if (opts.delaySeconds !== undefined) {
+        delaySeconds = parseInt(opts.delaySeconds, 10);
+        if (Number.isNaN(delaySeconds) || delaySeconds < 0) {
+          printError("--delay-seconds must be a non-negative integer.");
+          process.exit(1);
+        }
       }
 
-      const payload: Record<string, unknown> = {
-        name: opts.name,
-        filter_criteria: filterCriteria,
-        sampling_rate: samplingRate,
-        delay_seconds: delaySeconds,
-        is_active: !opts.inactive,
-      };
-      if (opts.evaluatorId) payload.evaluator_id = opts.evaluatorId;
-      if (opts.judgeId) payload.judge_id = opts.judgeId;
+      const flagPayload: Record<string, unknown> = {};
+      if (opts.name !== undefined) flagPayload.name = opts.name;
+      if (opts.evaluatorId !== undefined) flagPayload.evaluator_id = opts.evaluatorId;
+      if (opts.judgeId !== undefined) flagPayload.judge_id = opts.judgeId;
+      if (filterCriteria !== undefined) flagPayload.filter_criteria = filterCriteria;
+      if (samplingRate !== undefined) flagPayload.sampling_rate = samplingRate;
+      if (delaySeconds !== undefined) flagPayload.delay_seconds = delaySeconds;
+      if (opts.inactive !== undefined) flagPayload.is_active = !opts.inactive;
+
+      const payload: Record<string, unknown> = { ...filePayload, ...flagPayload };
+
+      if (!opts.fromFile) {
+        if (payload.sampling_rate === undefined) payload.sampling_rate = 1.0;
+        if (payload.delay_seconds === undefined) payload.delay_seconds = 10;
+        if (payload.is_active === undefined) payload.is_active = true;
+        if (payload.filter_criteria === undefined) payload.filter_criteria = {};
+      }
+
+      if (typeof payload.name !== "string" || payload.name.length === 0) {
+        printError("--name is required (provide via --name or --from-file).");
+        process.exit(1);
+      }
+      if (!payload.evaluator_id && !payload.judge_id) {
+        printError("Either --evaluator-id or --judge-id is required.");
+        process.exit(1);
+      }
+      if (payload.evaluator_id && payload.judge_id) {
+        printError("--evaluator-id and --judge-id are mutually exclusive.");
+        process.exit(1);
+      }
 
       const spinner = ora("Creating filter...").start();
       try {

--- a/cli/src/commands/otel-filter/create.ts
+++ b/cli/src/commands/otel-filter/create.ts
@@ -110,8 +110,9 @@ YAML manifest (only needed for custom extractor_rules):
 
       let samplingRate: number | undefined;
       if (opts.samplingRate !== undefined) {
-        samplingRate = parseFloat(opts.samplingRate);
-        if (Number.isNaN(samplingRate) || samplingRate < 0 || samplingRate > 1) {
+        const raw = opts.samplingRate.trim();
+        samplingRate = Number(raw);
+        if (raw === "" || !Number.isFinite(samplingRate) || samplingRate < 0 || samplingRate > 1) {
           printError("--sampling-rate must be a number between 0.0 and 1.0.");
           process.exit(1);
         }
@@ -119,8 +120,9 @@ YAML manifest (only needed for custom extractor_rules):
 
       let delaySeconds: number | undefined;
       if (opts.delaySeconds !== undefined) {
-        delaySeconds = parseInt(opts.delaySeconds, 10);
-        if (Number.isNaN(delaySeconds) || delaySeconds < 0) {
+        const raw = opts.delaySeconds.trim();
+        delaySeconds = Number(raw);
+        if (raw === "" || !Number.isInteger(delaySeconds) || delaySeconds < 0) {
           printError("--delay-seconds must be a non-negative integer.");
           process.exit(1);
         }

--- a/cli/src/commands/otel-filter/create.ts
+++ b/cli/src/commands/otel-filter/create.ts
@@ -41,12 +41,12 @@ export function registerCreateCommand(otelFilter: Command): void {
     .option("--inactive", "Create the filter as inactive")
     .option(
       "-f, --from-file <path>",
-      "Load filter spec from a YAML or JSON file. CLI flags override file values.",
+      "Load filter spec from a YAML/JSON file. Required only when the filter needs extractor_rules (custom input/output extraction).",
     )
     .addHelpText(
       "after",
       `
-Target — exactly one of --evaluator-id or --judge-id is required (either via flags or --from-file).
+Target — exactly one of --evaluator-id or --judge-id is required.
   --evaluator-id  Runs a single evaluator (one score, one justification).
   --judge-id      Runs a judge — a bundle of evaluators that produces an
                   aggregate verdict plus per-evaluator scores. Use this
@@ -66,8 +66,17 @@ Examples:
       --filter-criteria '{"conditions":[{"column":"resource","type":"string","key":"service.name","operator":"=","value":"construction_assistant_agent"}]}' \\
       --delay-seconds 5
 
-  # Load the full filter spec (including extractor_rules) from a YAML file
-  $ scorable otel-filter create -f ./filter.yaml`,
+YAML manifest (only needed for custom extractor_rules):
+  When your traces don't follow the OTel GenAI shape (Claude Code, OpenInference,
+  custom instrumentations) the eval needs to be told where input/output lives.
+  Carry that mapping as extractor_rules inside a YAML file. The flag-based
+  invocation above stays unchanged for everything else.
+
+  $ scorable otel-filter create -f ./filter.yaml
+  $ scorable otel-filter create -f ./filter.yaml --inactive    # override one field
+
+  See examples/otel-filters/ for reference manifests and the README's
+  "OTEL Trace Evaluation Filters" section for the extractor_rules schema.`,
     )
     .action(async (opts: CreateOptions) => {
       let filePayload: Record<string, unknown> = {};

--- a/cli/src/commands/otel-filter/index.ts
+++ b/cli/src/commands/otel-filter/index.ts
@@ -3,6 +3,7 @@ import { registerCreateCommand } from "./create.js";
 import { registerListCommand } from "./list.js";
 import { registerDeleteCommand } from "./delete.js";
 import { registerUpdateCommand } from "./update.js";
+import { registerValidateCommand } from "./validate.js";
 
 export function registerOtelFilterCommands(program: Command): void {
   const otelFilter = program
@@ -13,4 +14,5 @@ export function registerOtelFilterCommands(program: Command): void {
   registerListCommand(otelFilter);
   registerUpdateCommand(otelFilter);
   registerDeleteCommand(otelFilter);
+  registerValidateCommand(otelFilter);
 }

--- a/cli/src/commands/otel-filter/index.ts
+++ b/cli/src/commands/otel-filter/index.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { registerCreateCommand } from "./create.js";
 import { registerListCommand } from "./list.js";
 import { registerDeleteCommand } from "./delete.js";
+import { registerUpdateCommand } from "./update.js";
 
 export function registerOtelFilterCommands(program: Command): void {
   const otelFilter = program
@@ -10,5 +11,6 @@ export function registerOtelFilterCommands(program: Command): void {
 
   registerCreateCommand(otelFilter);
   registerListCommand(otelFilter);
+  registerUpdateCommand(otelFilter);
   registerDeleteCommand(otelFilter);
 }

--- a/cli/src/commands/otel-filter/update.ts
+++ b/cli/src/commands/otel-filter/update.ts
@@ -13,11 +13,14 @@ interface UpdateOptions {
 export function registerUpdateCommand(otelFilter: Command): void {
   otelFilter
     .command("update <id>")
-    .description("Update an OTEL trace evaluation filter from a YAML or JSON file")
+    .description("Update an OTEL trace evaluation filter from a YAML/JSON manifest")
     .requiredOption("-f, --from-file <path>", "Filter spec path (YAML or JSON)")
     .addHelpText(
       "after",
       `
+Pairs with the YAML-manifest workflow used by \`create -f\`. Edit the file,
+re-apply with this command.
+
 Example:
   $ scorable otel-filter update <filter-id> -f ./filter.yaml`,
     )

--- a/cli/src/commands/otel-filter/update.ts
+++ b/cli/src/commands/otel-filter/update.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey } from "../../auth.js";
+import { apiRequest } from "../../client.js";
+import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
+import { loadFilterYaml } from "../../lib/filter-yaml.js";
+
+interface UpdateOptions {
+  fromFile: string;
+}
+
+export function registerUpdateCommand(otelFilter: Command): void {
+  otelFilter
+    .command("update <id>")
+    .description("Update an OTEL trace evaluation filter from a YAML or JSON file")
+    .requiredOption("-f, --from-file <path>", "Filter spec path (YAML or JSON)")
+    .addHelpText(
+      "after",
+      `
+Example:
+  $ scorable otel-filter update <filter-id> -f ./filter.yaml`,
+    )
+    .action(async (id: string, opts: UpdateOptions) => {
+      let source: string;
+      try {
+        source = fs.readFileSync(opts.fromFile, "utf8");
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        printError(`Failed to read --from-file: ${msg}`);
+        process.exit(1);
+      }
+
+      let payload: Record<string, unknown>;
+      try {
+        payload = loadFilterYaml(source) as unknown as Record<string, unknown>;
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        printError(msg);
+        process.exit(1);
+      }
+
+      const spinner = ora("Updating filter...").start();
+      try {
+        const apiKey = await requireApiKey();
+        const result = await apiRequest(
+          "PATCH",
+          `v1/otel/evaluation-filters/${encodeURIComponent(id)}`,
+          { payload, apiKey },
+        );
+        spinner.stop();
+        if (result === null) {
+          process.exit(1);
+        }
+        printSuccess(`Filter ${id} updated.`);
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/otel-filter/validate.ts
+++ b/cli/src/commands/otel-filter/validate.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey } from "../../auth.js";
+import { apiRequestStatus } from "../../client.js";
+import { printError, printSuccess, handleSdkError } from "../../output.js";
+import { loadFilterYaml } from "../../lib/filter-yaml.js";
+import { CliError } from "../../types.js";
+
+interface ValidateOptions {
+  fromFile: string;
+}
+
+export function registerValidateCommand(otelFilter: Command): void {
+  otelFilter
+    .command("validate")
+    .description("Validate an OTEL trace evaluation filter spec without saving")
+    .requiredOption("-f, --from-file <path>", "Filter spec path (YAML or JSON)")
+    .addHelpText(
+      "after",
+      `
+Example:
+  $ scorable otel-filter validate -f ./filter.yaml`,
+    )
+    .action(async (opts: ValidateOptions) => {
+      let source: string;
+      try {
+        source = fs.readFileSync(opts.fromFile, "utf8");
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        printError(`Failed to read --from-file: ${msg}`);
+        throw new CliError(2, msg);
+      }
+
+      let payload: Record<string, unknown>;
+      try {
+        payload = loadFilterYaml(source) as unknown as Record<string, unknown>;
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        printError(msg);
+        throw new CliError(2, msg);
+      }
+
+      const spinner = ora("Validating filter...").start();
+      try {
+        const apiKey = await requireApiKey();
+        const result = await apiRequestStatus("POST", "v1/otel/evaluation-filters/validate", {
+          payload,
+          apiKey,
+        });
+        spinner.stop();
+
+        if (!result.ok) {
+          if (result.status === 400) {
+            throw new CliError(2, "Filter schema validation failed.");
+          }
+          throw new CliError(1, `Validation request failed (status ${result.status}).`);
+        }
+
+        const data = (result.data ?? {}) as { warnings?: unknown };
+        const warnings = Array.isArray(data.warnings) ? (data.warnings as string[]) : [];
+        if (warnings.length > 0) {
+          for (const w of warnings) {
+            console.error(`warning: ${w}`);
+          }
+        }
+        printSuccess("OK");
+      } catch (e) {
+        spinner.stop();
+        if (e instanceof CliError) throw e;
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/otel-filter/validate.ts
+++ b/cli/src/commands/otel-filter/validate.ts
@@ -36,7 +36,7 @@ Example:
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         printError(`Failed to read --from-file: ${msg}`);
-        throw new CliError(2, msg);
+        throw new CliError(1, msg);
       }
 
       let payload: Record<string, unknown>;

--- a/cli/src/commands/otel-filter/validate.ts
+++ b/cli/src/commands/otel-filter/validate.ts
@@ -19,6 +19,13 @@ export function registerValidateCommand(otelFilter: Command): void {
     .addHelpText(
       "after",
       `
+Useful in CI to fail builds on a bad manifest before applying.
+
+Exit codes:
+  0   schema valid; no warnings
+  0   schema valid; warnings written to stderr (e.g. rules don't match any recent span)
+  2   schema invalid (local Zod failure or server 400)
+
 Example:
   $ scorable otel-filter validate -f ./filter.yaml`,
     )

--- a/cli/src/lib/filter-yaml.ts
+++ b/cli/src/lib/filter-yaml.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+import yaml from "js-yaml";
+
+const Match = z
+  .object({
+    span_name: z
+      .object({
+        eq: z.string().optional(),
+        contains: z.string().optional(),
+        starts_with: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+const Locator = z
+  .object({
+    kind: z.enum(["span_attr", "event_attr", "resource_attr"]),
+    key: z.string(),
+    event_name: z.string().optional(),
+    value_path: z.string().optional(),
+  })
+  .strict();
+
+const TextRule = z
+  .object({
+    emit: z.literal("text"),
+    match: Match.optional(),
+    role: z.enum(["user", "assistant"]),
+    locator: Locator,
+    tool_name: z.string().optional(),
+  })
+  .strict();
+
+const RequestResponseRule = z
+  .object({
+    emit: z.literal("request_response"),
+    match: Match.optional(),
+    input_locator: Locator,
+    output_locator: Locator,
+  })
+  .strict();
+
+const ToolPairRule = z
+  .object({
+    emit: z.literal("tool_pair"),
+    match: Match.optional(),
+    input_locator: Locator,
+    output_locator: Locator,
+    tool_name: z.string().optional(),
+    tool_name_locator: Locator.optional(),
+  })
+  .strict();
+
+const GenAiMessagesRule = z
+  .object({
+    emit: z.literal("genai_messages"),
+    match: Match.optional(),
+    input_locator: Locator,
+    output_locator: Locator,
+  })
+  .strict();
+
+const ExtractorRule = z.discriminatedUnion("emit", [
+  TextRule,
+  RequestResponseRule,
+  ToolPairRule,
+  GenAiMessagesRule,
+]);
+
+export const FilterYamlSchema = z
+  .object({
+    name: z.string(),
+    evaluator_id: z.string().optional(),
+    judge_id: z.string().optional(),
+    filter_criteria: z.record(z.string(), z.unknown()).default({}),
+    sampling_rate: z.number().min(0).max(1).optional(),
+    delay_seconds: z.number().int().min(0).optional(),
+    is_active: z.boolean().optional(),
+    extractor_rules: z.array(ExtractorRule).default([]),
+  })
+  .strict()
+  .refine((v) => Boolean(v.evaluator_id) !== Boolean(v.judge_id), {
+    message: "exactly one of evaluator_id or judge_id is required",
+  });
+
+export type FilterYaml = z.infer<typeof FilterYamlSchema>;
+
+export function loadFilterYaml(source: string): FilterYaml {
+  let raw: unknown;
+  try {
+    raw = yaml.load(source);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid YAML: ${msg}`);
+  }
+  const result = FilterYamlSchema.safeParse(raw);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`);
+    throw new Error(`Invalid filter YAML:\n${issues.join("\n")}`);
+  }
+  return result.data;
+}

--- a/cli/src/lib/filter-yaml.ts
+++ b/cli/src/lib/filter-yaml.ts
@@ -16,14 +16,30 @@ const Match = z
   })
   .strict();
 
-const Locator = z
-  .object({
-    kind: z.enum(["span_attr", "event_attr", "resource_attr"]),
-    key: z.string(),
-    event_name: z.string().optional(),
-    value_path: z.string().optional(),
-  })
-  .strict();
+const Locator = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("span_attr"),
+      key: z.string(),
+      value_path: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("resource_attr"),
+      key: z.string(),
+      value_path: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("event_attr"),
+      key: z.string(),
+      event_name: z.string(),
+      value_path: z.string().optional(),
+    })
+    .strict(),
+]);
 
 const TextRule = z
   .object({
@@ -76,7 +92,7 @@ export const FilterYamlSchema = z
     name: z.string(),
     evaluator_id: z.string().optional(),
     judge_id: z.string().optional(),
-    filter_criteria: z.record(z.string(), z.unknown()).default({}),
+    filter_criteria: Match.default({ conditions: [] }),
     sampling_rate: z.number().min(0).max(1).optional(),
     delay_seconds: z.number().int().min(0).optional(),
     is_active: z.boolean().optional(),

--- a/cli/src/lib/filter-yaml.ts
+++ b/cli/src/lib/filter-yaml.ts
@@ -1,16 +1,18 @@
 import { z } from "zod";
 import yaml from "js-yaml";
 
+const MatchCondition = z
+  .object({
+    column: z.string(),
+    operator: z.string(),
+    value: z.union([z.string(), z.number(), z.boolean()]).optional(),
+    key: z.string().optional(),
+  })
+  .strict();
+
 const Match = z
   .object({
-    span_name: z
-      .object({
-        eq: z.string().optional(),
-        contains: z.string().optional(),
-        starts_with: z.string().optional(),
-      })
-      .strict()
-      .optional(),
+    conditions: z.array(MatchCondition).default([]),
   })
   .strict();
 

--- a/cli/tests/otel-filter-yaml.test.ts
+++ b/cli/tests/otel-filter-yaml.test.ts
@@ -66,6 +66,45 @@ extractor_rules:
 `;
     expect(() => loadFilterYaml(badRule)).toThrow();
   });
+
+  it("rejects event_attr locator without event_name", () => {
+    const bad = `
+name: x
+judge_id: j1
+filter_criteria: {}
+extractor_rules:
+  - emit: text
+    role: user
+    locator: { kind: event_attr, key: bash_command }
+`;
+    expect(() => loadFilterYaml(bad)).toThrow(/event_name/);
+  });
+
+  it("rejects span_attr locator with event_name", () => {
+    const bad = `
+name: x
+judge_id: j1
+filter_criteria: {}
+extractor_rules:
+  - emit: text
+    role: user
+    locator: { kind: span_attr, key: x, event_name: foo }
+`;
+    expect(() => loadFilterYaml(bad)).toThrow(/event_name/);
+  });
+
+  it("rejects filter_criteria that is not a Match shape", () => {
+    const bad = `
+name: x
+judge_id: j1
+filter_criteria: { foo: 1 }
+extractor_rules:
+  - emit: request_response
+    input_locator: { kind: span_attr, key: i }
+    output_locator: { kind: span_attr, key: o }
+`;
+    expect(() => loadFilterYaml(bad)).toThrow(/filter_criteria|foo/);
+  });
 });
 
 describe("example filter manifests", () => {

--- a/cli/tests/otel-filter-yaml.test.ts
+++ b/cli/tests/otel-filter-yaml.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { loadFilterYaml, FilterYamlSchema } from "../src/lib/filter-yaml.js";
+
+const validYaml = `
+name: my-filter
+judge_id: 0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91
+filter_criteria: {}
+extractor_rules:
+  - emit: request_response
+    input_locator: { kind: span_attr, key: input.value }
+    output_locator: { kind: span_attr, key: output.value }
+`;
+
+describe("filter yaml loader", () => {
+  it("parses a complete filter spec", () => {
+    const parsed = loadFilterYaml(validYaml);
+    expect(parsed.name).toBe("my-filter");
+    expect(parsed.extractor_rules).toHaveLength(1);
+  });
+
+  it("rejects unknown top-level fields", () => {
+    const bad = validYaml + "\nunknown_field: 1";
+    expect(() => loadFilterYaml(bad)).toThrow(/unknown_field/);
+  });
+
+  it("rejects invalid YAML", () => {
+    expect(() => loadFilterYaml(":\n  - malformed")).toThrow();
+  });
+
+  it("requires either evaluator_id or judge_id", () => {
+    const noTarget = `
+name: x
+filter_criteria: {}
+extractor_rules:
+  - emit: request_response
+    input_locator: { kind: span_attr, key: i }
+    output_locator: { kind: span_attr, key: o }
+`;
+    expect(() => loadFilterYaml(noTarget)).toThrow(/evaluator_id|judge_id/);
+  });
+
+  it("rejects both evaluator_id and judge_id set", () => {
+    const both = `
+name: x
+evaluator_id: e1
+judge_id: j1
+filter_criteria: {}
+extractor_rules:
+  - emit: request_response
+    input_locator: { kind: span_attr, key: i }
+    output_locator: { kind: span_attr, key: o }
+`;
+    expect(() => loadFilterYaml(both)).toThrow(/evaluator_id|judge_id/);
+  });
+
+  it("rejects extractor_rule with unknown emit", () => {
+    const badRule = `
+name: x
+judge_id: j1
+filter_criteria: {}
+extractor_rules:
+  - emit: nope
+    locator: { kind: span_attr, key: x }
+`;
+    expect(() => loadFilterYaml(badRule)).toThrow();
+  });
+});
+
+// Reference the export so type-check covers it.
+export const _schema = FilterYamlSchema;

--- a/cli/tests/otel-filter-yaml.test.ts
+++ b/cli/tests/otel-filter-yaml.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import * as path from "node:path";
+import * as fsCb from "node:fs";
 import { loadFilterYaml, FilterYamlSchema } from "../src/lib/filter-yaml.js";
 
 const validYaml = `
@@ -64,6 +66,18 @@ extractor_rules:
 `;
     expect(() => loadFilterYaml(badRule)).toThrow();
   });
+});
+
+describe("example filter manifests", () => {
+  const dir = path.resolve(__dirname, "../examples/otel-filters");
+  const files = fsCb.readdirSync(dir).filter((f) => f.endsWith(".yaml"));
+
+  for (const file of files) {
+    it(`${file} parses through loadFilterYaml`, () => {
+      const source = fsCb.readFileSync(path.join(dir, file), "utf8");
+      expect(() => loadFilterYaml(source)).not.toThrow();
+    });
+  }
 });
 
 // Reference the export so type-check covers it.

--- a/cli/tests/otel-filter.test.ts
+++ b/cli/tests/otel-filter.test.ts
@@ -270,6 +270,42 @@ describe("TestOtelFilterList", () => {
   });
 });
 
+describe("TestOtelFilterUpdate", () => {
+  it("test_update__sends_PATCH_with_merged_file_body", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "scorable-"));
+    const file = path.join(tmp, "u.yaml");
+    fs.writeFileSync(
+      file,
+      `
+name: updated
+judge_id: 0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91
+filter_criteria: {}
+extractor_rules:
+  - emit: request_response
+    input_locator: { kind: span_attr, key: i }
+    output_locator: { kind: span_attr, key: o }
+`,
+    );
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ...sampleFilter, name: "updated" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCli(["otel-filter", "update", FILTER_ID, "-f", file]);
+
+    expect(result.exitCode).toBe(0);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain(`/v1/otel/evaluation-filters/${FILTER_ID}`);
+    expect(init.method).toBe("PATCH");
+    const body = JSON.parse(init.body);
+    expect(body.name).toBe("updated");
+    expect(body.extractor_rules[0].emit).toBe("request_response");
+  });
+});
+
 describe("TestOtelFilterDelete", () => {
   it("test_delete__exits_nonzero_on_failure_and_does_not_print_success", async () => {
     // Regression: previously printed "Filter X deleted." even when the request

--- a/cli/tests/otel-filter.test.ts
+++ b/cli/tests/otel-filter.test.ts
@@ -147,6 +147,36 @@ describe("TestOtelFilterCreate", () => {
     expect(result.stderr).toContain("between 0.0 and 1.0");
   });
 
+  it("test_create__rejects_sampling_rate_with_trailing_garbage", async () => {
+    const result = await runCli([
+      "otel-filter",
+      "create",
+      "--name",
+      "x",
+      "--evaluator-id",
+      EVALUATOR_ID,
+      "--sampling-rate",
+      "0.5foo",
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("between 0.0 and 1.0");
+  });
+
+  it("test_create__rejects_non_integer_delay_seconds", async () => {
+    const result = await runCli([
+      "otel-filter",
+      "create",
+      "--name",
+      "x",
+      "--evaluator-id",
+      EVALUATOR_ID,
+      "--delay-seconds",
+      "1.5",
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("non-negative integer");
+  });
+
   it("test_create__rejects_negative_delay_seconds", async () => {
     const result = await runCli([
       "otel-filter",

--- a/cli/tests/otel-filter.test.ts
+++ b/cli/tests/otel-filter.test.ts
@@ -306,6 +306,123 @@ extractor_rules:
   });
 });
 
+describe("TestOtelFilterValidate", () => {
+  it("test_validate__exits_zero_when_schema_is_valid_and_no_warnings", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "scorable-"));
+    const file = path.join(tmp, "v.yaml");
+    fs.writeFileSync(
+      file,
+      `
+name: v
+judge_id: 0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91
+filter_criteria: {}
+extractor_rules:
+  - emit: request_response
+    input_locator: { kind: span_attr, key: i }
+    output_locator: { kind: span_attr, key: o }
+`,
+    );
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ warnings: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCli(["otel-filter", "validate", "-f", file]);
+
+    expect(result.exitCode).toBe(0);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/v1/otel/evaluation-filters/validate");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body);
+    expect(body.name).toBe("v");
+    expect(body.extractor_rules[0].emit).toBe("request_response");
+  });
+
+  it("test_validate__exits_zero_with_stderr_warnings_when_server_returns_warnings", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "scorable-"));
+    const file = path.join(tmp, "w.yaml");
+    fs.writeFileSync(
+      file,
+      `
+name: w
+judge_id: 0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91
+filter_criteria: {}
+extractor_rules:
+  - emit: request_response
+    input_locator: { kind: span_attr, key: i }
+    output_locator: { kind: span_attr, key: o }
+`,
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ warnings: ["unknown attr foo"] }),
+      }),
+    );
+
+    const result = await runCli(["otel-filter", "validate", "-f", file]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("unknown attr foo");
+  });
+
+  it("test_validate__exits_two_on_schema_error_from_server", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "scorable-"));
+    const file = path.join(tmp, "bad.yaml");
+    fs.writeFileSync(
+      file,
+      `
+name: v
+judge_id: 0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91
+filter_criteria: {}
+extractor_rules:
+  - emit: text
+    role: user
+    locator: { kind: span_attr, key: x }
+`,
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ errors: [{ msg: "completeness" }] }),
+      }),
+    );
+
+    const result = await runCli(["otel-filter", "validate", "-f", file]);
+
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("test_validate__exits_two_when_local_zod_parse_fails", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "scorable-"));
+    const file = path.join(tmp, "bad-local.yaml");
+    fs.writeFileSync(
+      file,
+      `
+name: v
+judge_id: 0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91
+filter_criteria: {}
+extractor_rules:
+  - emit: nonsense_emit_kind
+`,
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCli(["otel-filter", "validate", "-f", file]);
+
+    expect(result.exitCode).toBe(2);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("TestOtelFilterDelete", () => {
   it("test_delete__exits_nonzero_on_failure_and_does_not_print_success", async () => {
     // Regression: previously printed "Filter X deleted." even when the request

--- a/cli/tests/otel-filter.test.ts
+++ b/cli/tests/otel-filter.test.ts
@@ -1,4 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 import { runCli } from "./helpers/run-cli.js";
 
 const EVALUATOR_ID = "053df10f-b0c7-400b-892e-46ce3aa1e430";
@@ -157,6 +160,66 @@ describe("TestOtelFilterCreate", () => {
     ]);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("non-negative");
+  });
+
+  it("test_create__reads_yaml_from_file_and_posts_it_as_json", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "scorable-"));
+    const file = path.join(tmp, "f.yaml");
+    fs.writeFileSync(
+      file,
+      `
+name: from-file
+judge_id: 0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91
+filter_criteria: {}
+extractor_rules:
+  - emit: request_response
+    input_locator: { kind: span_attr, key: i }
+    output_locator: { kind: span_attr, key: o }
+`,
+    );
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve({ ...sampleFilter, name: "from-file" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCli(["otel-filter", "create", "-f", file]);
+
+    expect(result.exitCode).toBe(0);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.name).toBe("from-file");
+    expect(body.judge_id).toBe("0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91");
+    expect(body.extractor_rules[0].emit).toBe("request_response");
+  });
+
+  it("test_create__cli_flags_override_file_values", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "scorable-"));
+    const file = path.join(tmp, "f.yaml");
+    fs.writeFileSync(
+      file,
+      `
+name: from-file
+judge_id: 0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91
+filter_criteria: {}
+`,
+    );
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve(sampleFilter),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCli(["otel-filter", "create", "-f", file, "--name", "overridden"]);
+
+    expect(result.exitCode).toBe(0);
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.name).toBe("overridden");
+    expect(body.judge_id).toBe("0193b6a0-e75d-7a47-9c6f-2f3e3b8f7c91");
   });
 });
 


### PR DESCRIPTION
## Summary

Adds YAML-driven `otel-filter` workflows so OTEL evaluation filters with extractor rules can be authored, version-controlled, and applied from CI.

Backend counterpart: root-signals/rs#3225 — that PR introduces `extractor_rules` on `OtelTraceEvaluationFilter` plus the new `POST /v1/otel/evaluation-filters/validate/` endpoint this CLI calls into.

## What's in

- New `cli/src/lib/filter-yaml.ts` — strict Zod schema + `loadFilterYaml`. Rejects unknown top-level fields (so backend-internal flags can't accidentally leak through). Requires exactly one of `evaluator_id` / `judge_id`.
- `otel-filter create -f <file>` — extends the existing command. CLI flag values override file values.
- `otel-filter update <id> -f <file>` — new command, sends PATCH.
- `otel-filter validate -f <file>` — new command, dry-run validation. Exit 0 (clean), 0 with stderr warnings (reference mismatches), 2 (schema invalid, local OR server).
- Three reference manifests in `cli/examples/otel-filters/`:
  - `openinference-agent.yaml` — single-span agent with `input.value` / `output.value`.
  - `claude-code.yaml` — Claude Code's interaction span (user prompt) + tool spans (input/output events).
  - `genai-explicit.yaml` — gen_ai messages with custom attribute keys.
- README section "OTEL evaluation filters".

## Compatibility

- No changes to existing `create` flag-only flow — defaults applied as before when `-f` is unset.
- No other commands touched.

## Test plan

- [x] `npx vitest run` — 177 tests passing (incl. new YAML loader, create-from-file, update, validate, example-manifest parsing).
- [x] `npm run build` — TypeScript strict, clean.
- [x] `npm run lint` — oxlint 0 warnings/0 errors.
- [x] End-to-end smoke against local backend: created a Claude Code filter via `otel-filter create -f`, sent a prompt through Claude Code, confirmed eval ran with the extracted user prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OTEL evaluation filter management: create (now supports loading from YAML/JSON files), update, delete, and validate commands.
  * YAML-driven filter configs with extractor rules; CLI flag overrides merge with file inputs.

* **Documentation**
  * Expanded CLI README with OTEL trace evaluation filters guide and three reference manifests (examples/otel-filters).

* **Tests**
  * New tests for YAML loader, CLI file-based flows, validation, and error handling.

* **Chores**
  * Added runtime schema validation dependency and included example YAMLs in published files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->