### PR TITLE
CLI v0.9.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.0
+
+- Add `scorable otel-filter update <id>` and `scorable otel-filter validate` commands.
+- Add `-f, --from-file` to `scorable otel-filter create` for YAML/JSON filter manifests with custom `extractor_rules`.
+- Add reference manifests under `examples/otel-filters/` (Claude Code, OpenInference, GenAI).
+
 ## 0.8.0
 
 - Add `scorable otel-filter` command group for managing OTEL trace evaluation filters (`create`, `list`, `delete`). Wires an evaluator (`--evaluator-id`) or judge (`--judge-id`) to incoming traces; filters auto-run against matching traces and the result lands back on the trace as a child span carrying the OpenTelemetry GenAI evaluation attributes.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",


### PR DESCRIPTION
## Summary

Release CLI v0.9.0.

## CHANGELOG

- Add `scorable otel-filter update <id>` and `scorable otel-filter validate` commands.
- Add `-f, --from-file` to `scorable otel-filter create` for YAML/JSON filter manifests with custom `extractor_rules`.
- Add reference manifests under `examples/otel-filters/` (Claude Code, OpenInference, GenAI).

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test` — 182/182 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new update and validate commands for scorable otel-filter.
  * Added -f, --from-file option to create command for YAML/JSON manifest support with custom extractor rules.
  * Added reference manifest examples for Claude Code, OpenInference, and GenAI integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->