### PR TITLE
Release Python SDK v1.9.1 and TypeScript SDK v0.6.1

### DIFF
--- a/python/docs/CHANGELOG.md
+++ b/python/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.1
+
+- Patch high-severity dependency vulnerability (urllib3 2.7.0 — CVE-2026-44431: sensitive headers forwarded in proxied redirects, decompression-bomb bypass)
+
 ## 1.9.0
 
 - Add file upload support

--- a/python/src/scorable/__about__.py
+++ b/python/src/scorable/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present juho.ylikyla <juho.ylikyla@scorable.ai>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.9.0"
+__version__ = "1.9.1"

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+
+- Patch high-severity dependency vulnerabilities (fast-uri 3.1.2 — host confusion via percent-encoded authority delimiters, path traversal via percent-encoded dot segments)
+
 ## 0.6.0
 
 - Add file upload support

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "TypeScript SDK for Scorable API",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Patch releases for Python SDK and TypeScript SDK to address high-severity dependency vulnerabilities.

## Changes

- **Python SDK 1.9.0 → 1.9.1**: upgrades `urllib3` to 2.7.0 (already in `uv.lock` via security PR #120)
- **TypeScript SDK 0.6.0 → 0.6.1**: upgrades `fast-uri` to 3.1.2 (already in `package-lock.json` via security PR #120)

## Vulnerabilities resolved

| Package | Severity | Details |
|---------|----------|---------|
| urllib3 | High | CVE-2026-44431: sensitive headers forwarded in proxied low-level redirects |
| urllib3 | High | Decompression-bomb safeguards bypassed in streaming API |
| fast-uri | High | Host confusion via percent-encoded authority delimiters |
| fast-uri | High | Path traversal via percent-encoded dot segments |

## Next

After this merges: CLI v0.9.1 release to pick up `@root-signals/scorable@0.6.1`.

## Test plan

- [x] Python: 22/22 tests passed, ruff clean
- [x] TypeScript: 95/96 tests passed (1 skipped), eslint clean
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Python SDK patched to version 1.9.1 addressing high-severity dependency vulnerabilities
  * TypeScript SDK patched to version 0.6.1 addressing high-severity dependency vulnerabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/root-signals/scorable-sdk/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->