### PR TITLE
Release CLI v0.9.1

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1
+
+- Update `@root-signals/scorable` to 0.6.1 to patch fast-uri high-severity vulnerabilities (host confusion, path traversal via percent-encoded segments)
+
 ## 0.9.0
 
 - Add `scorable otel-filter update <id>` and `scorable otel-filter validate` commands.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.8.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@root-signals/scorable-cli",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@root-signals/scorable": "^0.6.0",
+        "@root-signals/scorable": "^0.6.1",
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
@@ -1379,9 +1379,9 @@
       "license": "MIT"
     },
     "node_modules/@root-signals/scorable": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.6.0.tgz",
-      "integrity": "sha512-o+sAASn+rH9HN1iFZ2jt3SfbJ04/FWpEdlrT5um3oIg85jwRBuA9S+Id2qXoxPXVhiemAcL2H2fLHUgZq2olNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.6.1.tgz",
+      "integrity": "sha512-DO+2vWrIOSowdZ9m/zYhknY5Pav0A8ABPRbYlDHYjP/A1nWj5OzQIqZobKd60fsvLUs/DKrKFLfLwgUOWMsWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.15.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",
-    "@root-signals/scorable": "^0.6.0",
+    "@root-signals/scorable": "^0.6.1",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",


### PR DESCRIPTION
## Summary

Patch release to pull in the fast-uri security fix from TypeScript SDK 0.6.1.

## Changes

- `@root-signals/scorable` bumped `^0.6.0` → `^0.6.1`
- `package-lock.json` updated (picks up fast-uri 3.1.2)
- Version bumped `0.9.0` → `0.9.1`

## Vulnerabilities resolved

| Package | Severity | Details |
|---------|----------|---------|
| fast-uri | High | Host confusion via percent-encoded authority delimiters |
| fast-uri | High | Path traversal via percent-encoded dot segments |

## Test plan

- [x] 182/182 tests passed, oxlint clean
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.9.1
  * Updated `@root-signals/scorable` dependency to 0.6.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/root-signals/scorable-sdk/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->