### PR TITLE
feat(ts-sdk): add models.verify() and bump to 0.7.0

### DIFF
--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.0
+
+- Add `models.verify(...)` to test an unsaved LLM model configuration via `POST /v1/models/verify/`. Exposes `VerifyModelData` and `VerifyModelResponse` types.
+- Add `file_id` to `JudgeGenerateParams` so callers can attach an uploaded document to judge generation. Optional, defaults to `null`.
+- Remove `ModelListParams` (type-only breaking change). `models.list(...)` now accepts the shared `ListParams` — the previous `name`/`vendor` fields were not supported by the API.
+
 ## 0.6.1
 
 - Patch high-severity dependency vulnerabilities (fast-uri 3.1.2 — host confusion via percent-encoded authority delimiters, path traversal via percent-encoded dot segments)

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@root-signals/scorable",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@root-signals/scorable",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.15.0"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "TypeScript SDK for Scorable API",
   "type": "module",
   "main": "dist/index.js",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -47,7 +47,8 @@ export type {
   ModelDetail,
   CreateModelData,
   UpdateModelData,
-  ModelListParams,
+  VerifyModelData,
+  VerifyModelResponse,
 } from './resources/models.js';
 
 export type {

--- a/typescript/src/resources/models.ts
+++ b/typescript/src/resources/models.ts
@@ -5,6 +5,7 @@ type Client = ReturnType<typeof import('openapi-fetch').default<paths>>;
 
 export type ModelList = components['schemas']['ModelList'];
 export type ModelDetail = components['schemas']['Model'];
+export type VerifyModelResponse = components['schemas']['ModelTestResponse'];
 
 export interface CreateModelData {
   name: string;
@@ -24,9 +25,11 @@ export interface UpdateModelData {
   max_output_token_count?: number;
 }
 
-export interface ModelListParams extends ListParams {
-  name?: string;
-  vendor?: string;
+export interface VerifyModelData {
+  model: string;
+  api_key?: string;
+  url?: string;
+  max_output_token_count?: number;
 }
 
 export class ModelsResource {
@@ -35,7 +38,7 @@ export class ModelsResource {
   /**
    * List all available models
    */
-  async list(params: ModelListParams = {}): Promise<PaginatedResponse<ModelList>> {
+  async list(params: ListParams = {}): Promise<PaginatedResponse<ModelList>> {
     const { data, error } = await this._client.GET('/v1/models/', {
       params: { query: params },
     });
@@ -150,6 +153,27 @@ export class ModelsResource {
         'PATCH_MODEL_FAILED',
         error,
         `Failed to patch model ${id}`,
+      );
+    }
+
+    return responseData;
+  }
+
+  /**
+   * Verify an unsaved LLM model configuration by sending a test prompt.
+   * Useful for validating model parameters before creating the model.
+   */
+  async verify(data: VerifyModelData): Promise<VerifyModelResponse> {
+    const { data: responseData, error } = await this._client.POST('/v1/models/verify/', {
+      body: data,
+    });
+
+    if (error) {
+      throw new ScorableError(
+        (error as ApiError)?.status ?? 500,
+        'VERIFY_MODEL_FAILED',
+        error,
+        'Failed to verify model',
       );
     }
 

--- a/typescript/tests/unit/models.test.ts
+++ b/typescript/tests/unit/models.test.ts
@@ -1,0 +1,179 @@
+import { TestUtils } from '../helpers/test-utils';
+import { mockClient } from '../helpers/mock-client';
+
+describe('ModelsResource', () => {
+  let client: any;
+
+  beforeEach(() => {
+    client = TestUtils.createMockClient();
+    mockClient.reset();
+  });
+
+  describe('list', () => {
+    it('should list models with no params', async () => {
+      mockClient.setMockResponse('GET', '/v1/models/', {
+        data: {
+          results: [
+            {
+              id: 'model-123',
+              name: 'gpt-4-turbo',
+              owner: { id: 'user-1', first_name: 'A', last_name: 'B' },
+              provider: { id: 'p-1', name: 'OpenAI' },
+              visibility: 'PRIVATE',
+            },
+          ],
+          next: null,
+          previous: null,
+        },
+        error: undefined,
+      });
+
+      const result = await client.models.list();
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].name).toBe('gpt-4-turbo');
+      expect(mockClient.GET).toHaveBeenCalledWith('/v1/models/', {
+        params: { query: {} },
+      });
+    });
+
+    it('should forward pagination and ordering params', async () => {
+      await client.models.list({ page_size: 25, cursor: 'next-token', ordering: 'name' });
+
+      expect(mockClient.GET).toHaveBeenCalledWith('/v1/models/', {
+        params: { query: { page_size: 25, cursor: 'next-token', ordering: 'name' } },
+      });
+    });
+  });
+
+  describe('get', () => {
+    it('should fetch a model by id', async () => {
+      const modelId = 'model-123';
+      mockClient.setMockResponse('GET', '/v1/models/{id}/', {
+        data: {
+          id: modelId,
+          name: 'gpt-4-turbo',
+          model: 'gpt-4-turbo',
+          max_token_count: 8000,
+          max_output_token_count: 4000,
+        },
+        error: undefined,
+      });
+
+      const result = await client.models.get(modelId);
+
+      expect(result.id).toBe(modelId);
+      expect(mockClient.GET).toHaveBeenCalledWith('/v1/models/{id}/', {
+        params: { path: { id: modelId } },
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('should create a model', async () => {
+      const body = {
+        name: 'my-custom-gpt',
+        model: 'gpt-4-turbo',
+        default_key: 'sk-test',
+      };
+      mockClient.setMockResponse('POST', '/v1/models/', {
+        data: { id: 'new-1', ...body },
+        error: undefined,
+      });
+
+      const result = await client.models.create(body);
+
+      expect(result.id).toBe('new-1');
+      expect(mockClient.POST).toHaveBeenCalledWith('/v1/models/', { body });
+    });
+
+    it('should throw on error', async () => {
+      mockClient.setMockError('POST', '/v1/models/', {
+        detail: 'Already exists',
+      });
+
+      await expect(client.models.create({ name: 'dupe' })).rejects.toThrow();
+    });
+  });
+
+  describe('update', () => {
+    it('should PUT to /v1/models/{id}/', async () => {
+      const id = 'model-123';
+      const body = { name: 'renamed' };
+      mockClient.setMockResponse('PUT', '/v1/models/{id}/', {
+        data: { id, ...body },
+        error: undefined,
+      });
+
+      await client.models.update(id, body);
+
+      expect(mockClient.PUT).toHaveBeenCalledWith('/v1/models/{id}/', {
+        params: { path: { id } },
+        body,
+      });
+    });
+  });
+
+  describe('patch', () => {
+    it('should PATCH to /v1/models/{id}/', async () => {
+      const id = 'model-123';
+      const body = { name: 'partial' };
+      mockClient.setMockResponse('PATCH', '/v1/models/{id}/', {
+        data: { id, ...body },
+        error: undefined,
+      });
+
+      await client.models.patch(id, body);
+
+      expect(mockClient.PATCH).toHaveBeenCalledWith('/v1/models/{id}/', {
+        params: { path: { id } },
+        body,
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('should DELETE /v1/models/{id}/', async () => {
+      const id = 'model-123';
+      mockClient.setMockResponse('DELETE', '/v1/models/{id}/', {
+        data: undefined,
+        error: undefined,
+      });
+
+      await client.models.delete(id);
+
+      expect(mockClient.DELETE).toHaveBeenCalledWith('/v1/models/{id}/', {
+        params: { path: { id } },
+      });
+    });
+  });
+
+  describe('verify', () => {
+    it('should POST to /v1/models/verify/ and return the test response', async () => {
+      const body = {
+        model: 'gpt-4-turbo',
+        api_key: 'sk-test',
+        url: 'https://example.com',
+        max_output_token_count: 100,
+      };
+      mockClient.setMockResponse('POST', '/v1/models/verify/', {
+        data: { success: true, model: body.model, response: 'pong' },
+        error: undefined,
+      });
+
+      const result = await client.models.verify(body);
+
+      expect(result.success).toBe(true);
+      expect(result.response).toBe('pong');
+      expect(mockClient.POST).toHaveBeenCalledWith('/v1/models/verify/', { body });
+    });
+
+    it('should throw on error', async () => {
+      mockClient.setMockError('POST', '/v1/models/verify/', {
+        detail: 'Bad key',
+      });
+
+      await expect(client.models.verify({ model: 'gpt-4-turbo' })).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `client.models.verify({ model, api_key?, url?, max_output_token_count? })` calling `POST /v1/models/verify/` — tests an unsaved LLM model configuration before creating it. Exposes `VerifyModelData` and `VerifyModelResponse` types.
- Drop `ModelListParams`. The previous `name` and `vendor` fields were never supported by the API (verified against `operations.models_list` in the generated OpenAPI types). `models.list(...)` now takes the shared `ListParams`. This is a type-only breaking change.
- Changelog also records the `file_id` addition to `JudgeGenerateParams` from #124, which has not yet been released.
- Bump SDK version `0.6.1` → `0.7.0`.

## Test plan

- [ ] `npm run check-all` passes in `typescript/` (type-check + eslint + prettier + vitest)
- [ ] New `tests/unit/models.test.ts` covers list/get/create/update/patch/delete/verify happy paths and an error path
- [ ] Manual smoke: `client.models.verify({ model: "gpt-4-turbo", api_key: "sk-..." })` returns `{ success, response, model, ... }`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model verification endpoint added to validate configurations before saving.
  * Judge generation extended with support for attaching uploaded documents.

* **Breaking Changes**
  * Model listing now uses standardized shared parameters instead of custom parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/root-signals/scorable-sdk/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->