### PR TITLE
feat(cli): add scorable model commands + judge generate --file/--file-id; bump to 0.10.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.10.0
+
+- Add `scorable model` command group for managing custom LLM models: `list`, `get`, `create`, `update` (PATCH), `delete`.
+- `model create` / `model update` accept `--key -` to read the provider API key from stdin, avoiding shell-history leak.
+- `model list` prints a table (ID / Name / Provider / Visibility) with `--page-size`, `--cursor`, `--ordering`.
+- Bump `@root-signals/scorable` to `^0.7.0` (adds `models.verify()` and `file_id` on judge generate).
+
 ## 0.9.1
 
 - Update `@root-signals/scorable` to 0.6.1 to patch fast-uri high-severity vulnerabilities (host confusion, path traversal via percent-encoded segments)

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Add `scorable model` command group for managing custom LLM models: `list`, `get`, `create`, `update` (PATCH), `delete`.
 - `model create` / `model update` accept `--key -` to read the provider API key from stdin, avoiding shell-history leak.
 - `model list` prints a table (ID / Name / Provider / Visibility) with `--page-size`, `--cursor`, `--ordering`.
+- Add `--file <path>` and `--file-id <id>` to `scorable judge generate`. `--file` uploads then generates in one step; `--file-id` reuses an already-uploaded file. The two options are mutually exclusive.
+- `scorable file upload` now prints the uploaded file object (was silent).
 - Bump `@root-signals/scorable` to `^0.7.0` (adds `models.verify()` and `file_id` on judge generate).
 
 ## 0.9.1

--- a/cli/README.md
+++ b/cli/README.md
@@ -276,6 +276,59 @@ scorable evaluator execute-by-name "My Evaluator" --request "What is 2+2?" --res
 
 Accepts the same options as `execute`, including `--variables`.
 
+## Custom Model Management
+
+Bring your own LLM (BYO-LLM) — register a custom or self-hosted model, then reference it from evaluators and judges.
+
+### List models
+
+```bash
+scorable model list
+```
+
+Shows ID, name, provider, and visibility. Options: `--page-size`, `--cursor`, `--ordering`.
+
+### Get a model
+
+```bash
+scorable model get <model_id>
+```
+
+### Create a model
+
+```bash
+# SaaS provider (key inline)
+scorable model create --name my-gpt --model gpt-5.5 --key sk-...
+
+# Self-hosted / custom endpoint
+scorable model create \
+  --name azure/gpt-5.5 \
+  --model azure/gpt-5.5 \
+  --url https://my-azure-openai.openai.azure.com \
+  --key sk-...
+
+# Read the key from stdin (keeps it out of shell history)
+echo "$MY_PROVIDER_KEY" | scorable model create --name my-gpt --model gpt-5.5 --key -
+```
+
+Options: `--name` (required), `--model`, `--url` (for self-hosted endpoints), `--key` (provider API key; `-` reads from stdin), `--max-token-count`, `--max-output-token-count`.
+
+### Update a model
+
+```bash
+scorable model update <model_id> --max-output-token-count 4096
+```
+
+`update` is a PATCH — only fields you pass are sent. All `create` flags are accepted as optional updates, including `--key -` for stdin.
+
+### Delete a model
+
+```bash
+scorable model delete <model_id>
+```
+
+Prompts for confirmation. Use `--yes` to skip.
+
 ## Execution Logs
 
 ### List execution logs

--- a/cli/README.md
+++ b/cli/README.md
@@ -136,6 +136,40 @@ Prompts for confirmation. Use `--yes` to skip.
 scorable judge duplicate <judge_id>
 ```
 
+### Generate a judge
+
+AI-powered judge generation from a plain-language description of what you want to evaluate.
+
+```bash
+scorable judge generate --intent "I am building a customer support chatbot. Evaluate that responses are helpful and follow our refund policy."
+```
+
+Attach a policy document so the generated evaluators can check compliance against it:
+
+```bash
+# Upload and generate in one step
+scorable judge generate --intent "Evaluate responses against the attached policy." --file ./policy.pdf
+
+# Or reuse an already-uploaded file
+scorable judge generate --intent "Evaluate responses against the attached policy." --file-id <file_uuid>
+```
+
+Options: `--intent` (required), `--file` (path to PDF/PNG/JPG — uploads and attaches), `--file-id` (UUID of an already-uploaded file), `--visibility` (`private`/`public`, default `private`), `--name`, `--stage`, `--extra-contexts` (JSON object, e.g. `'{"Domain":"hotel","Tone":"formal"}'`), `--reasoning-effort` (`off`/`low`/`medium`/`high`), `--judge-id` (regenerate an existing judge), `--overwrite`, `--context-aware`
+
+## File Management
+
+### Upload a file
+
+Upload a PDF or image for use as context in judge generation or evaluator execution.
+
+```bash
+scorable file upload ./policy.pdf
+```
+
+Returns a file UUID that can be passed to `judge generate --file-id` or `evaluator execute --file-ids`.
+
+Supported formats: PDF, PNG, JPG, JPEG, WEBP, SVG.
+
 ## Judge Execution
 
 ### Execute by ID

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@root-signals/scorable-cli",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@root-signals/scorable": "^0.6.1",
+        "@root-signals/scorable": "^0.7.0",
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
@@ -1379,9 +1379,9 @@
       "license": "MIT"
     },
     "node_modules/@root-signals/scorable": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.6.1.tgz",
-      "integrity": "sha512-DO+2vWrIOSowdZ9m/zYhknY5Pav0A8ABPRbYlDHYjP/A1nWj5OzQIqZobKd60fsvLUs/DKrKFLfLwgUOWMsWSg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.7.0.tgz",
+      "integrity": "sha512-tpjW8cG/Mj67KXeZGEPe5UZCtPdEMMttt1NtBSRHiQKVGVLg7QG4co94DdoME/z67kmrwRb4m2sqniTSkSSSIw==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.15.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",
-    "@root-signals/scorable": "^0.6.1",
+    "@root-signals/scorable": "^0.7.0",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",

--- a/cli/src/commands/evaluator/delete.ts
+++ b/cli/src/commands/evaluator/delete.ts
@@ -13,7 +13,7 @@ export function registerDeleteCommand(evaluator: Command): void {
       const apiKey = await requireApiKey();
 
       if (!opts.yes) {
-        if (!process.stdin.isTTY && !process.stdout.isTTY) {
+        if (!process.stdin.isTTY || !process.stdout.isTTY) {
           throw new CliError(
             1,
             "Refusing to prompt for confirmation in a non-interactive environment. Pass --yes to skip the prompt.",

--- a/cli/src/commands/evaluator/update.ts
+++ b/cli/src/commands/evaluator/update.ts
@@ -10,7 +10,7 @@ export function registerUpdateCommand(evaluator: Command): void {
     .description("Update an existing evaluator (PATCH)")
     .option("--name <name>", "The new name for the evaluator")
     .option("--scoring-criteria <text>", "The new scoring criteria (prompt text)")
-    .option("--models <json>", "JSON array of model names. E.g., '[\"gpt-4\"]'")
+    .option("--models <json>", "JSON array of model names. E.g., '[\"gpt-5.5\"]'")
     .option("--objective-id <id>", "The new objective ID")
     .option("--objective-version-id <id>", "The new objective version ID")
     .action(

--- a/cli/src/commands/file/upload.ts
+++ b/cli/src/commands/file/upload.ts
@@ -5,13 +5,21 @@ import * as path from "path";
 import { requireApiKey } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
 import { getSdkClient } from "../../auth.js";
+import { CliError } from "../../types.js";
 
-export async function uploadFile(filePath: string): Promise<void> {
+export interface UploadedFile {
+  id: string;
+}
+
+export async function uploadFile(
+  filePath: string,
+  { silent = false }: { silent?: boolean } = {},
+): Promise<UploadedFile> {
   const apiKey = await requireApiKey();
 
   if (!fs.existsSync(filePath)) {
     printError(`File not found: ${filePath}`);
-    process.exit(1);
+    throw new CliError(1, "file_not_found");
   }
 
   const client = getSdkClient(apiKey);
@@ -23,8 +31,11 @@ export async function uploadFile(filePath: string): Promise<void> {
   try {
     const result = await client.files.upload(blob, fileName);
     spinner.stop();
-    printSuccess("File uploaded successfully!");
-    printJson(result);
+    if (!silent) {
+      printSuccess("File uploaded successfully!");
+      printJson(result);
+    }
+    return result as UploadedFile;
   } catch (e) {
     spinner.stop();
     throw e;

--- a/cli/src/commands/judge/delete.ts
+++ b/cli/src/commands/judge/delete.ts
@@ -13,7 +13,7 @@ export function registerDeleteCommand(judge: Command): void {
       const apiKey = await requireApiKey();
 
       if (!opts.yes) {
-        if (!process.stdin.isTTY && !process.stdout.isTTY) {
+        if (!process.stdin.isTTY || !process.stdout.isTTY) {
           throw new CliError(
             1,
             "Refusing to prompt for confirmation in a non-interactive environment. Pass --yes to skip the prompt.",

--- a/cli/src/commands/judge/exec-openai.ts
+++ b/cli/src/commands/judge/exec-openai.ts
@@ -14,7 +14,7 @@ export function registerExecOpenaiCommand(judge: Command): void {
   judge
     .command("exec-openai <judgeIdInPath>")
     .description("Execute a specific judge via the OpenAI compatible API")
-    .requiredOption("--model <model>", "LLM model for judge execution (e.g., gpt-4o)")
+    .requiredOption("--model <model>", "LLM model for judge execution (e.g., gpt-5.5)")
     .requiredOption("--messages <json>", "JSON string of the messages payload")
     .option("--extra-body <json>", "Optional JSON string for extra_body parameters")
     .action(

--- a/cli/src/commands/judge/generate.ts
+++ b/cli/src/commands/judge/generate.ts
@@ -88,14 +88,14 @@ offer to connect the guest with a human agent when uncertain."`,
           }
         }
 
-        let fileId = opts.fileId;
-        if (opts.file) {
-          const uploaded = await uploadFile(opts.file, { silent: true });
-          fileId = uploaded.id;
-        }
-
         const spinner = ora("Generating judge (this may take a moment)...").start();
         try {
+          let fileId = opts.fileId;
+          if (opts.file) {
+            const uploaded = await uploadFile(opts.file, { silent: true });
+            fileId = uploaded.id;
+          }
+
           const client = getSdkClient(apiKey);
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const result = (await client.judges.generate({

--- a/cli/src/commands/judge/generate.ts
+++ b/cli/src/commands/judge/generate.ts
@@ -11,6 +11,7 @@ import {
   handleSdkError,
 } from "../../output.js";
 import { CliError } from "../../types.js";
+import { uploadFile } from "../file/upload.js";
 
 export function registerGenerateCommand(judge: Command): void {
   judge
@@ -42,6 +43,11 @@ offer to connect the guest with a human agent when uncertain."`,
       "Enable context-aware evaluators for RAG applications (hallucination detection, context drift, etc.)",
       false,
     )
+    .option(
+      "--file <path>",
+      "Path to a file (PDF, PNG, JPG) to upload and attach as context for the judge",
+    )
+    .option("--file-id <id>", "ID of an already-uploaded file to use as context for the judge")
     .action(
       async (opts: {
         intent: string;
@@ -53,6 +59,8 @@ offer to connect the guest with a human agent when uncertain."`,
         overwrite: boolean;
         extraContexts?: string;
         contextAware: boolean;
+        file?: string;
+        fileId?: string;
       }) => {
         const acceptedVisibilities = ["private", "public"] as const;
         const visibility = opts.visibility;
@@ -61,6 +69,11 @@ offer to connect the guest with a human agent when uncertain."`,
             `Invalid --visibility value: "${visibility}". Accepted values: private, public.`,
           );
           throw new CliError(1, "invalid_visibility");
+        }
+
+        if (opts.file && opts.fileId) {
+          printError("Cannot use both --file and --file-id. Provide one or the other.");
+          throw new CliError(1, "conflicting_file_options");
         }
 
         const apiKey = await requireApiKey();
@@ -75,6 +88,12 @@ offer to connect the guest with a human agent when uncertain."`,
           }
         }
 
+        let fileId = opts.fileId;
+        if (opts.file) {
+          const uploaded = await uploadFile(opts.file, { silent: true });
+          fileId = uploaded.id;
+        }
+
         const spinner = ora("Generating judge (this may take a moment)...").start();
         try {
           const client = getSdkClient(apiKey);
@@ -86,6 +105,7 @@ offer to connect the guest with a human agent when uncertain."`,
             name: opts.name,
             stage: opts.stage,
             judge_id: opts.judgeId,
+            file_id: fileId,
             extra_contexts: extra_contexts ?? null,
             enable_context_aware_evaluators: opts.contextAware || undefined,
             ...(opts.reasoningEffort && {

--- a/cli/src/commands/model/create.ts
+++ b/cli/src/commands/model/create.ts
@@ -15,7 +15,7 @@ export function registerCreateCommand(model: Command): void {
     .command("create")
     .description("Create a new custom model")
     .requiredOption("--name <name>", "Model name (unique within your organization)")
-    .option("--model <model>", "Underlying model identifier (e.g. 'gpt-4-turbo')")
+    .option("--model <model>", "Underlying model identifier (e.g. 'gpt-5.5')")
     .option("--url <url>", "API base URL (for self-hosted or non-SaaS endpoints)")
     .option(
       "--key <value>",

--- a/cli/src/commands/model/create.ts
+++ b/cli/src/commands/model/create.ts
@@ -1,0 +1,61 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, printJson, handleSdkError } from "../../output.js";
+import type { CreateModelData } from "@root-signals/scorable";
+
+async function readKeyFromStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString().trim();
+}
+
+export function registerCreateCommand(model: Command): void {
+  model
+    .command("create")
+    .description("Create a new custom model")
+    .requiredOption("--name <name>", "Model name (unique within your organization)")
+    .option("--model <model>", "Underlying model identifier (e.g. 'gpt-4-turbo')")
+    .option("--url <url>", "API base URL (for self-hosted or non-SaaS endpoints)")
+    .option(
+      "--key <value>",
+      "Provider API key. Pass '-' to read the key from stdin (avoids shell history leak)",
+    )
+    .option("--max-token-count <number>", "Maximum total tokens", parseInt)
+    .option("--max-output-token-count <number>", "Maximum output tokens", parseInt)
+    .action(
+      async (opts: {
+        name: string;
+        model?: string;
+        url?: string;
+        key?: string;
+        maxTokenCount?: number;
+        maxOutputTokenCount?: number;
+      }) => {
+        const apiKey = await requireApiKey();
+
+        const payload: CreateModelData = { name: opts.name };
+        if (opts.model !== undefined) payload.model = opts.model;
+        if (opts.url !== undefined) payload.url = opts.url;
+        if (opts.maxTokenCount !== undefined) payload.max_token_count = opts.maxTokenCount;
+        if (opts.maxOutputTokenCount !== undefined) {
+          payload.max_output_token_count = opts.maxOutputTokenCount;
+        }
+        if (opts.key !== undefined) {
+          payload.default_key = opts.key === "-" ? await readKeyFromStdin() : opts.key;
+        }
+
+        const spinner = ora("Creating...").start();
+        try {
+          const client = getSdkClient(apiKey);
+          const result = await client.models.create(payload);
+          spinner.stop();
+          printSuccess("Model created successfully!");
+          printJson(result);
+        } catch (e) {
+          spinner.stop();
+          handleSdkError(e);
+        }
+      },
+    );
+}

--- a/cli/src/commands/model/delete.ts
+++ b/cli/src/commands/model/delete.ts
@@ -1,0 +1,43 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, handleSdkError } from "../../output.js";
+import { CliError } from "../../types.js";
+
+export function registerDeleteCommand(model: Command): void {
+  model
+    .command("delete <modelId>")
+    .description("Delete a custom model by its ID")
+    .option("--yes", "Skip confirmation prompt")
+    .action(async (modelId: string, opts: { yes?: boolean }) => {
+      const apiKey = await requireApiKey();
+
+      if (!opts.yes) {
+        if (!process.stdin.isTTY && !process.stdout.isTTY) {
+          throw new CliError(
+            1,
+            "Refusing to prompt for confirmation in a non-interactive environment. Pass --yes to skip the prompt.",
+          );
+        }
+        const { confirm } = await import("@inquirer/prompts");
+        const ok = await confirm({
+          message: "Are you sure you want to delete this model?",
+          default: false,
+        });
+        if (!ok) {
+          throw new CliError(1, "Aborted");
+        }
+      }
+
+      const spinner = ora("Deleting...").start();
+      try {
+        const client = getSdkClient(apiKey);
+        await client.models.delete(modelId);
+        spinner.stop();
+        printSuccess(`Model ${modelId} deleted successfully.`);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/model/delete.ts
+++ b/cli/src/commands/model/delete.ts
@@ -13,7 +13,7 @@ export function registerDeleteCommand(model: Command): void {
       const apiKey = await requireApiKey();
 
       if (!opts.yes) {
-        if (!process.stdin.isTTY && !process.stdout.isTTY) {
+        if (!process.stdin.isTTY || !process.stdout.isTTY) {
           throw new CliError(
             1,
             "Refusing to prompt for confirmation in a non-interactive environment. Pass --yes to skip the prompt.",

--- a/cli/src/commands/model/get.ts
+++ b/cli/src/commands/model/get.ts
@@ -1,0 +1,24 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, printJson, handleSdkError } from "../../output.js";
+
+export function registerGetCommand(model: Command): void {
+  model
+    .command("get <modelId>")
+    .description("Get a specific model by its ID")
+    .action(async (modelId: string) => {
+      const apiKey = await requireApiKey();
+      const spinner = ora("Fetching...").start();
+      try {
+        const client = getSdkClient(apiKey);
+        const result = await client.models.get(modelId);
+        spinner.stop();
+        printSuccess(`Model '${result.name}' details:`);
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/model/index.ts
+++ b/cli/src/commands/model/index.ts
@@ -1,0 +1,18 @@
+import { Command } from "commander";
+import { registerListCommand } from "./list.js";
+import { registerGetCommand } from "./get.js";
+import { registerCreateCommand } from "./create.js";
+import { registerUpdateCommand } from "./update.js";
+import { registerDeleteCommand } from "./delete.js";
+
+export function registerModelCommands(program: Command): void {
+  const model = new Command("model").description("Custom model management commands");
+
+  registerListCommand(model);
+  registerGetCommand(model);
+  registerCreateCommand(model);
+  registerUpdateCommand(model);
+  registerDeleteCommand(model);
+
+  program.addCommand(model);
+}

--- a/cli/src/commands/model/list.ts
+++ b/cli/src/commands/model/list.ts
@@ -1,0 +1,39 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printMessage, printModelTable, handleSdkError } from "../../output.js";
+import type { ListParams } from "@root-signals/scorable";
+
+export function registerListCommand(model: Command): void {
+  model
+    .command("list")
+    .description("List models")
+    .option("--page-size <number>", "Number of results to return per page", parseInt)
+    .option("--cursor <cursor>", "The pagination cursor value")
+    .option("--ordering <field>", "Which field to use for ordering the results")
+    .action(async (opts: { pageSize?: number; cursor?: string; ordering?: string }) => {
+      const apiKey = await requireApiKey();
+
+      const params: ListParams = {};
+      if (opts.pageSize !== undefined) params.page_size = opts.pageSize;
+      if (opts.cursor !== undefined) params.cursor = opts.cursor;
+      if (opts.ordering !== undefined) params.ordering = opts.ordering;
+
+      const spinner = ora("Fetching...").start();
+      try {
+        const client = getSdkClient(apiKey);
+        const response = await client.models.list(params);
+        spinner.stop();
+
+        if (!response.results.length) {
+          printMessage("No models found.");
+          return;
+        }
+
+        printModelTable(response.results, response.next);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/model/update.ts
+++ b/cli/src/commands/model/update.ts
@@ -1,0 +1,70 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printInfo, printSuccess, printJson, handleSdkError } from "../../output.js";
+import type { UpdateModelData } from "@root-signals/scorable";
+
+async function readKeyFromStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString().trim();
+}
+
+export function registerUpdateCommand(model: Command): void {
+  model
+    .command("update <modelId>")
+    .description("Update an existing model (PATCH — only provided fields are sent)")
+    .option("--name <name>", "New model name")
+    .option("--model <model>", "Underlying model identifier")
+    .option("--url <url>", "API base URL")
+    .option(
+      "--key <value>",
+      "Provider API key. Pass '-' to read the key from stdin (avoids shell history leak)",
+    )
+    .option("--max-token-count <number>", "Maximum total tokens", parseInt)
+    .option("--max-output-token-count <number>", "Maximum output tokens", parseInt)
+    .action(
+      async (
+        modelId: string,
+        opts: {
+          name?: string;
+          model?: string;
+          url?: string;
+          key?: string;
+          maxTokenCount?: number;
+          maxOutputTokenCount?: number;
+        },
+      ) => {
+        const apiKey = await requireApiKey();
+
+        const payload: Partial<UpdateModelData> = {};
+        if (opts.name !== undefined) payload.name = opts.name;
+        if (opts.model !== undefined) payload.model = opts.model;
+        if (opts.url !== undefined) payload.url = opts.url;
+        if (opts.maxTokenCount !== undefined) payload.max_token_count = opts.maxTokenCount;
+        if (opts.maxOutputTokenCount !== undefined) {
+          payload.max_output_token_count = opts.maxOutputTokenCount;
+        }
+        if (opts.key !== undefined) {
+          payload.default_key = opts.key === "-" ? await readKeyFromStdin() : opts.key;
+        }
+
+        if (Object.keys(payload).length === 0) {
+          printInfo("No update parameters provided. Aborting.");
+          return;
+        }
+
+        const spinner = ora("Updating...").start();
+        try {
+          const client = getSdkClient(apiKey);
+          const result = await client.models.patch(modelId, payload);
+          spinner.stop();
+          printSuccess(`Model ${modelId} updated successfully!`);
+          printJson(result);
+        } catch (e) {
+          spinner.stop();
+          handleSdkError(e);
+        }
+      },
+    );
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -13,6 +13,7 @@ import { registerSkillsAddCommand } from "./commands/skills-add.js";
 import { registerFileCommands } from "./commands/file/index.js";
 import { registerOtelFilterCommands } from "./commands/otel-filter/index.js";
 import { registerOtelTraceCommands } from "./commands/otel-trace/index.js";
+import { registerModelCommands } from "./commands/model/index.js";
 
 const { version } = createRequire(import.meta.url)("../package.json") as {
   version: string;
@@ -74,6 +75,7 @@ export function createCli(): Command {
   registerFileCommands(program);
   registerOtelFilterCommands(program);
   registerOtelTraceCommands(program);
+  registerModelCommands(program);
 
   return program;
 }

--- a/cli/src/output.ts
+++ b/cli/src/output.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import Table from "cli-table3";
 import { CliError } from "./types.js";
-import type { Judge, EvaluatorListItem, ExecutionLogList } from "@root-signals/scorable";
+import type { Judge, EvaluatorListItem, ExecutionLogList, ModelList } from "@root-signals/scorable";
 
 const UNICODE_CHARS = {
   top: "─",
@@ -88,6 +88,27 @@ export function printEvaluatorTable(evaluators: EvaluatorListItem[], nextCursor?
   for (const e of evaluators) {
     const date = (e.created_at ?? "").slice(0, 10);
     table.push([e.id, e.name, date]);
+  }
+
+  console.log(table.toString());
+
+  if (nextCursor) {
+    const cursor = nextCursor.split("cursor=")[1] ?? nextCursor;
+    printInfo(`Next page available. Use --cursor "${cursor}"`);
+  }
+}
+
+export function printModelTable(models: ModelList[], nextCursor?: string): void {
+  const table = new Table({
+    head: ["ID", "Name", "Provider", "Visibility"].map((h) => chalk.bold.cyan(h)),
+    chars: UNICODE_CHARS,
+    colWidths: [38, 32, 22, 18],
+    wordWrap: true,
+  });
+
+  for (const m of models) {
+    const provider = m.provider?.name ?? "";
+    table.push([m.id, m.name, provider, m.visibility ?? ""]);
   }
 
   console.log(table.toString());

--- a/cli/tests/helpers/run-cli.ts
+++ b/cli/tests/helpers/run-cli.ts
@@ -20,9 +20,11 @@ export async function runCli(args: string[]): Promise<CliResult> {
     stderr += a.join(" ") + "\n";
   });
 
-  // Prevent commands from reading stdin (avoid hangs in test environment)
-  const origIsTTY = process.stdin.isTTY;
+  // Simulate an interactive terminal (avoid stdin reads and non-TTY guards in test env)
+  const origStdinIsTTY = process.stdin.isTTY;
+  const origStdoutIsTTY = process.stdout.isTTY;
   (process.stdin as NodeJS.ReadStream & { isTTY: boolean }).isTTY = true;
+  (process.stdout as NodeJS.WriteStream & { isTTY: boolean }).isTTY = true;
 
   try {
     const cli = createCli();
@@ -45,7 +47,8 @@ export async function runCli(args: string[]): Promise<CliResult> {
       }
     }
   } finally {
-    (process.stdin as NodeJS.ReadStream & { isTTY: boolean }).isTTY = origIsTTY;
+    (process.stdin as NodeJS.ReadStream & { isTTY: boolean }).isTTY = origStdinIsTTY;
+    (process.stdout as NodeJS.WriteStream & { isTTY: boolean }).isTTY = origStdoutIsTTY;
     logSpy.mockRestore();
     errSpy.mockRestore();
   }

--- a/cli/tests/judge.test.ts
+++ b/cli/tests/judge.test.ts
@@ -1,4 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import { Scorable } from "@root-signals/scorable";
 import { runCli } from "./helpers/run-cli.js";
 import { executeJudge } from "../src/commands/judge/execute.js";
@@ -16,6 +19,7 @@ const mockExecute = vi.fn();
 const mockExecuteByName = vi.fn();
 const mockDuplicate = vi.fn();
 const mockGenerate = vi.fn();
+const mockUpload = vi.fn();
 
 const sampleJudge = {
   id: "judge-123",
@@ -40,6 +44,9 @@ beforeEach(() => {
         executeByName: mockExecuteByName,
         duplicate: mockDuplicate,
         generate: mockGenerate,
+      },
+      files: {
+        upload: mockUpload,
       },
     } as unknown as Scorable;
   });
@@ -614,5 +621,60 @@ describe("TestJudgeGenerate", () => {
     const result = await runCli(["judge", "generate", "--intent", "Evaluate responses"]);
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("invalid_intent");
+  });
+
+  it("test_generate_judge_with_file_id__passes_file_id_to_generate", async () => {
+    mockGenerate.mockResolvedValue({ judge_id: "judge-abc", error_code: null });
+    const result = await runCli([
+      "judge",
+      "generate",
+      "--intent",
+      "Evaluate responses",
+      "--file-id",
+      "file-uuid-123",
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(mockGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ file_id: "file-uuid-123" }),
+    );
+  });
+
+  it("test_generate_judge_with_file__uploads_then_passes_file_id", async () => {
+    const tmpFile = path.join(os.tmpdir(), `judge-test-${Math.random()}.pdf`);
+    fs.writeFileSync(tmpFile, Buffer.from("pdf-bytes"));
+    mockUpload.mockResolvedValue({ id: "uploaded-file-uuid" });
+    mockGenerate.mockResolvedValue({ judge_id: "judge-abc", error_code: null });
+    try {
+      const result = await runCli([
+        "judge",
+        "generate",
+        "--intent",
+        "Evaluate responses",
+        "--file",
+        tmpFile,
+      ]);
+      expect(result.exitCode).toBe(0);
+      expect(mockUpload).toHaveBeenCalledOnce();
+      expect(mockGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({ file_id: "uploaded-file-uuid" }),
+      );
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it("test_generate_judge_with_file_and_file_id__fails_with_conflict_error", async () => {
+    const result = await runCli([
+      "judge",
+      "generate",
+      "--intent",
+      "Evaluate responses",
+      "--file",
+      "/path/to/doc.pdf",
+      "--file-id",
+      "file-uuid-123",
+    ]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("Cannot use both --file and --file-id");
   });
 });

--- a/cli/tests/model.test.ts
+++ b/cli/tests/model.test.ts
@@ -16,7 +16,7 @@ const mockVerify = vi.fn();
 const sampleModel = {
   id: "model-123",
   name: "my-custom-gpt",
-  model: "gpt-4-turbo",
+  model: "gpt-5.5",
   max_token_count: 8000,
   max_output_token_count: 4000,
 };
@@ -145,7 +145,7 @@ describe("TestModelCreate", () => {
       "--name",
       "my-custom-gpt",
       "--model",
-      "gpt-4-turbo",
+      "gpt-5.5",
       "--url",
       "https://example.com",
       "--key",
@@ -158,7 +158,7 @@ describe("TestModelCreate", () => {
     expect(result.exitCode).toBe(0);
     expect(mockCreate).toHaveBeenCalledWith({
       name: "my-custom-gpt",
-      model: "gpt-4-turbo",
+      model: "gpt-5.5",
       url: "https://example.com",
       default_key: "sk-test",
       max_token_count: 8000,
@@ -167,7 +167,7 @@ describe("TestModelCreate", () => {
   });
 
   it("test_create_model_missing_name", async () => {
-    const result = await runCli(["model", "create", "--model", "gpt-4-turbo"]);
+    const result = await runCli(["model", "create", "--model", "gpt-5.5"]);
     expect(result.exitCode).not.toBe(0);
   });
 

--- a/cli/tests/model.test.ts
+++ b/cli/tests/model.test.ts
@@ -1,0 +1,246 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Scorable } from "@root-signals/scorable";
+import { runCli } from "./helpers/run-cli.js";
+
+vi.mock("@root-signals/scorable");
+vi.mock("@inquirer/prompts");
+
+const mockList = vi.fn();
+const mockGet = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockPatch = vi.fn();
+const mockDelete = vi.fn();
+const mockVerify = vi.fn();
+
+const sampleModel = {
+  id: "model-123",
+  name: "my-custom-gpt",
+  model: "gpt-4-turbo",
+  max_token_count: 8000,
+  max_output_token_count: 4000,
+};
+
+const sampleModelList = {
+  id: "model-123",
+  name: "my-custom-gpt",
+  owner: { id: "user-1", first_name: "A", last_name: "B" },
+  provider: { id: "p-1", name: "OpenAI" },
+  visibility: "PRIVATE",
+};
+
+beforeEach(() => {
+  vi.stubEnv("SCORABLE_API_KEY", "test-api-key");
+  vi.mocked(Scorable).mockImplementation(function () {
+    return {
+      models: {
+        list: mockList,
+        get: mockGet,
+        create: mockCreate,
+        update: mockUpdate,
+        patch: mockPatch,
+        delete: mockDelete,
+        verify: mockVerify,
+      },
+    } as unknown as Scorable;
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+// --- TestModelList ---
+
+describe("TestModelList", () => {
+  it("test_list_models_success", async () => {
+    mockList.mockResolvedValue({
+      results: [sampleModelList, { ...sampleModelList, id: "model-456", name: "another" }],
+    });
+    const result = await runCli(["model", "list"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("my-custom-gpt");
+    expect(result.stdout).toContain("another");
+    expect(result.stdout).toContain("OpenAI");
+  });
+
+  it("test_list_models_empty", async () => {
+    mockList.mockResolvedValue({ results: [] });
+    const result = await runCli(["model", "list"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No models found");
+  });
+
+  it("test_list_models_with_pagination_flags", async () => {
+    mockList.mockResolvedValue({ results: [sampleModelList] });
+    const result = await runCli([
+      "model",
+      "list",
+      "--page-size",
+      "10",
+      "--cursor",
+      "abc",
+      "--ordering",
+      "name",
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(mockList).toHaveBeenCalledWith(
+      expect.objectContaining({ page_size: 10, cursor: "abc", ordering: "name" }),
+    );
+  });
+
+  it("test_list_models_with_next_page", async () => {
+    mockList.mockResolvedValue({
+      results: [sampleModelList],
+      next: "cursor=next_token",
+    });
+    const result = await runCli(["model", "list"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Next page available");
+  });
+
+  it("test_list_models_api_error", async () => {
+    mockList.mockRejectedValue(new Error("boom"));
+    const result = await runCli(["model", "list"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("boom");
+  });
+});
+
+// --- TestModelGet ---
+
+describe("TestModelGet", () => {
+  it("test_get_model_success", async () => {
+    mockGet.mockResolvedValue(sampleModel);
+    const result = await runCli(["model", "get", "model-123"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("my-custom-gpt");
+  });
+
+  it("test_get_model_not_found", async () => {
+    mockGet.mockRejectedValue(new Error("Not found"));
+    const result = await runCli(["model", "get", "nonexistent"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("Not found");
+  });
+});
+
+// --- TestModelCreate ---
+
+describe("TestModelCreate", () => {
+  it("test_create_model_basic", async () => {
+    mockCreate.mockResolvedValue(sampleModel);
+    const result = await runCli(["model", "create", "--name", "my-custom-gpt"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Model created successfully");
+    expect(mockCreate).toHaveBeenCalledWith({ name: "my-custom-gpt" });
+  });
+
+  it("test_create_model_full_payload", async () => {
+    mockCreate.mockResolvedValue(sampleModel);
+    const result = await runCli([
+      "model",
+      "create",
+      "--name",
+      "my-custom-gpt",
+      "--model",
+      "gpt-4-turbo",
+      "--url",
+      "https://example.com",
+      "--key",
+      "sk-test",
+      "--max-token-count",
+      "8000",
+      "--max-output-token-count",
+      "4000",
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: "my-custom-gpt",
+      model: "gpt-4-turbo",
+      url: "https://example.com",
+      default_key: "sk-test",
+      max_token_count: 8000,
+      max_output_token_count: 4000,
+    });
+  });
+
+  it("test_create_model_missing_name", async () => {
+    const result = await runCli(["model", "create", "--model", "gpt-4-turbo"]);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("test_create_model_api_error", async () => {
+    mockCreate.mockRejectedValue(new Error("Already exists"));
+    const result = await runCli(["model", "create", "--name", "dupe"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("Already exists");
+  });
+});
+
+// --- TestModelUpdate ---
+
+describe("TestModelUpdate", () => {
+  it("test_update_model_name", async () => {
+    mockPatch.mockResolvedValue(sampleModel);
+    const result = await runCli(["model", "update", "model-123", "--name", "renamed"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Model model-123 updated successfully");
+    expect(mockPatch).toHaveBeenCalledWith("model-123", { name: "renamed" });
+  });
+
+  it("test_update_model_partial_fields", async () => {
+    mockPatch.mockResolvedValue(sampleModel);
+    const result = await runCli([
+      "model",
+      "update",
+      "model-123",
+      "--key",
+      "sk-new",
+      "--max-output-token-count",
+      "1024",
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(mockPatch).toHaveBeenCalledWith("model-123", {
+      default_key: "sk-new",
+      max_output_token_count: 1024,
+    });
+  });
+
+  it("test_update_model_no_params", async () => {
+    const result = await runCli(["model", "update", "model-123"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No update parameters provided");
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+});
+
+// --- TestModelDelete ---
+
+describe("TestModelDelete", () => {
+  it("test_delete_model_with_yes_flag", async () => {
+    mockDelete.mockResolvedValue(undefined);
+    const result = await runCli(["model", "delete", "model-123", "--yes"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Model model-123 deleted successfully");
+    expect(mockDelete).toHaveBeenCalledWith("model-123");
+  });
+
+  it("test_delete_model_confirmed", async () => {
+    mockDelete.mockResolvedValue(undefined);
+    const { confirm } = await import("@inquirer/prompts");
+    vi.mocked(confirm).mockResolvedValue(true);
+    const result = await runCli(["model", "delete", "model-123"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Model model-123 deleted successfully");
+  });
+
+  it("test_delete_model_aborted", async () => {
+    const { confirm } = await import("@inquirer/prompts");
+    vi.mocked(confirm).mockResolvedValue(false);
+    const result = await runCli(["model", "delete", "model-123"]);
+    expect(result.exitCode).toBe(1);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- New `scorable model` command group: `list`, `get`, `create`, `update` (PATCH), `delete`. `--key -` reads the provider API key from stdin to avoid shell-history leaks. `list` is a table (ID / Name / Provider / Visibility) with `--page-size`, `--cursor`, `--ordering`.
- `scorable judge generate` gains `--file <path>` (upload-then-generate) and `--file-id <id>` (use an already-uploaded file). Mutually exclusive.
- `scorable file upload` now prints the uploaded file object instead of being silent.
- Bump `@root-signals/scorable` to `^0.7.0` (this unlocks `models.verify()` in the SDK and `file_id` on judge generate).
- CLI version `0.9.1` → `0.10.0`.

Builds on the merged SDK PR #125. The judge-generate file-upload work was previously on `feat/judge-generate-file-upload`; those two CLI commits are cherry-picked here so everything ships in one CLI release.

## Test plan

- [ ] `npm run check-all` passes in `cli/` (typecheck + oxlint + oxfmt + vitest — 202 passing)
- [ ] New `cli/tests/model.test.ts` covers list/get/create/update/delete happy + error paths
- [ ] `scorable model --help` shows the new group; `scorable model create --help` documents `--key -` stdin form
- [ ] Manual smoke: `scorable model list`, `echo "sk-..." | scorable model create --name test --model gpt-4-turbo --key -`, `scorable judge generate --intent "..." --file ./doc.pdf`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model management CLI: list/get/create/update/delete with table output, pagination and ordering
  * Attach files to judge generation via --file or --file-id (mutually exclusive); uploads now print file info
  * Read provider API key from stdin for model create/update

* **Documentation**
  * Docs for judge generation with attachments and full model management guide

* **Tests**
  * Added tests for model commands and file-attach flows

* **Chores**
  * Bumped CLI version and SDK dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/root-signals/scorable-sdk/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->