### PR TITLE
Update CLI evaluator commands to use scoring_criteria 

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@root-signals/scorable": "^0.7.0",
+        "@root-signals/scorable": "^0.8.0",
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
@@ -1379,9 +1379,9 @@
       "license": "MIT"
     },
     "node_modules/@root-signals/scorable": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.7.0.tgz",
-      "integrity": "sha512-tpjW8cG/Mj67KXeZGEPe5UZCtPdEMMttt1NtBSRHiQKVGVLg7QG4co94DdoME/z67kmrwRb4m2sqniTSkSSSIw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.8.0.tgz",
+      "integrity": "sha512-GmIgtczcfuAUGXG0VRsPJSgsTbxkZwzpqq5/XJD3Ltfl9iWtFDnIiiT9kKbnXNoq4fs7sEbyyL1eg9nACaIt5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.15.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",
-    "@root-signals/scorable": "^0.7.0",
+    "@root-signals/scorable": "^0.8.0",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",

--- a/cli/src/commands/evaluator/create.ts
+++ b/cli/src/commands/evaluator/create.ts
@@ -52,7 +52,7 @@ export function registerCreateCommand(evaluator: Command): void {
 
         const payload: EvaluatorCreateParams = {
           name: opts.name,
-          predicate: opts.scoringCriteria,
+          scoring_criteria: opts.scoringCriteria,
         };
 
         if (opts.intent) payload.intent = opts.intent;

--- a/cli/src/commands/evaluator/update.ts
+++ b/cli/src/commands/evaluator/update.ts
@@ -28,7 +28,7 @@ export function registerUpdateCommand(evaluator: Command): void {
 
         const payload: EvaluatorUpdateParams = {};
         if (opts.name !== undefined) payload.name = opts.name;
-        if (opts.scoringCriteria !== undefined) payload.prompt = opts.scoringCriteria;
+        if (opts.scoringCriteria !== undefined) payload.scoring_criteria = opts.scoringCriteria;
         if (opts.objectiveId !== undefined) payload.objective_id = opts.objectiveId;
         if (opts.objectiveVersionId !== undefined)
           payload.objective_version_id = opts.objectiveVersionId;

--- a/cli/tests/evaluator.test.ts
+++ b/cli/tests/evaluator.test.ts
@@ -289,7 +289,7 @@ describe("TestEvaluatorUpdate", () => {
     expect(result.exitCode).toBe(0);
     expect(mockUpdate).toHaveBeenCalledWith(
       "eval-123",
-      expect.objectContaining({ prompt: "New scoring criteria" }),
+      expect.objectContaining({ scoring_criteria: "New scoring criteria" }),
     );
   });
 

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@root-signals/scorable",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@root-signals/scorable",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.15.0"


### PR DESCRIPTION
## Summary

CLI follow-up for scorable-sdk PR #129. Must be merged **after** the TypeScript SDK from that PR is published to npm.

- evaluator create: predicate → scoring_criteria key in request body
- evaluator update: prompt → scoring_criteria key in request body
- Fix test expectation to match new field name

## Merge order

1. Merge PR #129 (Python + TypeScript SDK rename)
2. Bump TypeScript SDK version and publish to npm
3. Update cli/package.json dependency to the new published version
4. Merge this PR

## Test plan

- [ ] cd cli && npm test -- --testPathPattern evaluator
- [ ] cd cli && npm run typecheck — typechecks cleanly against published SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated scorable package dependency to the latest version.

* **Bug Fixes**
  * Corrected evaluator create and update commands to properly map the scoring criteria option to the API parameter.

* **Tests**
  * Updated evaluator tests to verify correct API parameter mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/root-signals/scorable-sdk/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->