### PR TITLE
Release CLI 0.11.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.11.0
+
+- Rename `evaluator create` and `evaluator update` to send `scoring_criteria` instead of `predicate`/`prompt`
+- Bump `@root-signals/scorable` to `^0.8.0`
+
 ## 0.10.0
 
 - Add `scorable model` command group for managing custom LLM models: `list`, `get`, `create`, `update` (PATCH), `delete`.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",


### PR DESCRIPTION
Bump CLI to 0.11.0 with changelog for the scoring_criteria rename.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * `evaluator create` and `evaluator update` commands now use `scoring_criteria` parameter instead of `predicate`/`prompt`
  * Updated supporting dependencies for compatibility and stability
  
* **Version**
  * CLI bumped to 0.11.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/root-signals/scorable-sdk/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->