### PR TITLE
Make API base URL configurable

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.0
+
+- Add `--api-url <url>` global flag to override the API base URL (on-prem deployments; also overridable via `SCORABLE_API_URL` env var)
+
 ## 0.11.0
 
 - Rename `evaluator create` and `evaluator update` to send `scoring_criteria` instead of `predicate`/`prompt`

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -61,6 +61,13 @@ export function createCli(): Command {
     .version(version, "-V, --version", "Print version number")
     .addHelpText("before", buildBanner(version))
     .addHelpText("after", buildGettingStarted())
+    .option("--api-url <url>", "API base URL (overrides SCORABLE_API_URL env var)")
+    .hook("preAction", (thisCommand) => {
+      const opts = thisCommand.optsWithGlobals() as { apiUrl?: string };
+      if (opts.apiUrl) {
+        process.env["SCORABLE_API_URL"] = opts.apiUrl;
+      }
+    })
     .exitOverride()
     .action(() => {
       program.outputHelp();

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0
+
+- Add `SCORABLE_API_URL` environment variable support for configuring the API base URL (on-prem deployments)
+
 ## 0.8.0
 
 - Rename `EvaluatorCreateParams.predicate` → `scoring_criteria`

--- a/typescript/eslint.config.mjs
+++ b/typescript/eslint.config.mjs
@@ -17,7 +17,8 @@ export default [
         setTimeout: 'readonly',
         setImmediate: 'readonly',
         Buffer: 'readonly',
-        fetch: 'readonly'
+        fetch: 'readonly',
+        process: 'readonly'
       }
     },
     plugins: {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "TypeScript SDK for Scorable API",
   "type": "module",
   "main": "dist/index.js",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -27,8 +27,10 @@ export class Scorable {
   public readonly files: FilesResource;
 
   constructor(config: ClientConfig) {
+    const envBaseUrl =
+      typeof process !== 'undefined' ? process.env?.['SCORABLE_API_URL'] : undefined;
     this.config = {
-      baseUrl: 'https://api.scorable.ai',
+      baseUrl: envBaseUrl ?? 'https://api.scorable.ai',
       timeout: 30000,
       ...config,
     };


### PR DESCRIPTION
## Summary

- **TypeScript SDK 0.9.0**: Constructor now reads `SCORABLE_API_URL` env var as a fallback, matching the behaviour already in the Python SDK and CLI. Explicit `baseUrl` in `ClientConfig` still takes precedence. Also registers `process` as an ESLint global (the SDK runs in Node.js).
- **CLI 0.12.0**: Adds a global `--api-url <url>` flag that overrides the API base URL for any subcommand. Writes through to `SCORABLE_API_URL` so `getBaseUrl()` needs no changes. Bumps `@root-signals/scorable` dep to `^0.9.0`.

Users can now reach a self-hosted instance three consistent ways:
```
# Env var (all SDKs + CLI)
SCORABLE_API_URL=https://my-instance.example.com scorable judge list

# CLI flag
scorable --api-url https://my-instance.example.com judge list

# Constructor (Python / TypeScript)
Scorable(api_key=..., base_url="https://my-instance.example.com")
new Scorable({ apiKey: ..., baseUrl: "https://my-instance.example.com" })
```

## Test Plan

- [ ] `npm test` passes in `typescript/` (108 tests)
- [ ] `npm test` passes in `cli/` (202 tests)
- [ ] Pre-commit hooks pass (TypeScript checks + CLI checks)
- [ ] Verify `SCORABLE_API_URL` env var routes requests to custom host in both SDK and CLI
- [ ] Verify `scorable --api-url <url> judge list` routes to custom host
- [ ] Verify explicit `baseUrl` in `new Scorable({ baseUrl: ... })` still overrides env var

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--api-url` global flag to the CLI to specify a custom API base URL
  * Added `SCORABLE_API_URL` environment variable support for configuring the API base URL in CLI and TypeScript packages

* **Chores**
  * Bumped CLI to v0.12.0 and TypeScript package to v0.9.0
  * Updated dependency on scorable package to ^0.9.0

* **Documentation**
  * Added changelog entries documenting the above changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/root-signals/scorable-sdk/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->