### PR TITLE
Release Python SDK 1.11.0 and TypeScript SDK 0.10.0

### DIFF
--- a/python/docs/CHANGELOG.md
+++ b/python/docs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.11.0
+
+- Add `tools` parameter (OpenAI-style tool catalog) to `evaluators.run`/`arun`/`run_by_name`/`arun_by_name`, `judges.run`/`arun`, and preset evaluator runners. Enables tool-aware evaluators like `Tool_Selection`.
+- Add `Tool_Selection` and `Knowledge_Retention` preset evaluator enum entries.
+- Multi-turn conversation turns: `content` is now nullable, and turns can carry structured `tool_calls` (assistant) and `tool_call_id` (new `tool` role) — see updated `examples/judge_multi_turn.py` and `examples/multi_turn_conversation.py`.
+
 ## 1.10.0
 
 - Rename `predicate` parameter to `scoring_criteria` in `Evaluators.create()`, `acreate()`, `update()`, and `aupdate()`

--- a/python/src/scorable/__about__.py
+++ b/python/src/scorable/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present juho.ylikyla <juho.ylikyla@scorable.ai>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.10.0"
+__version__ = "1.11.0"

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.0
+
+- Add `tools` field (OpenAI-style tool catalog) to `ExecutionPayload`. Enables tool-aware evaluators like Tool Selection.
+- Multi-turn conversation turns (`MessageTurnRequest`): `content` is now nullable, with new `tool_calls` (assistant) and `tool_call_id` fields, and a new `tool` role — see updated README multi-turn example.
+
 ## 0.9.0
 
 - Add `SCORABLE_API_URL` environment variable support for configuring the API base URL (on-prem deployments)

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "TypeScript SDK for Scorable API",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Cut releases for both SDKs to ship the OpenAI-shape tool catalog and structured `tool_calls` multi-turn conversation support added in #127.

### Python SDK 1.11.0
- Add `tools` parameter (OpenAI-style tool catalog) to `evaluators.run`/`arun`/`run_by_name`/`arun_by_name`, `judges.run`/`arun`, and preset evaluator runners. Enables tool-aware evaluators like `Tool_Selection`.
- Add `Tool_Selection` and `Knowledge_Retention` preset evaluator enum entries.
- Multi-turn conversation turns: `content` is now nullable, and turns can carry structured `tool_calls` (assistant) and `tool_call_id` (new `tool` role).

### TypeScript SDK 0.10.0
- Add `tools` field (OpenAI-style tool catalog) to `ExecutionPayload`.
- Multi-turn conversation turns (`MessageTurnRequest`): `content` is now nullable, with new `tool_calls` (assistant) and `tool_call_id` fields, and a new `tool` role.

CLI bump will follow in a separate PR once it picks up the new TS SDK and adds `--tools` + a fix for `isTurnArray` to accept nullable content.

## Test plan
- [x] TS lint + unit tests (`npm run lint && npm run test:unit`) — 105 passed
- [x] Python lint (`ruff check`, `ruff format --check`) — clean
- [ ] CI to run full Python pytest (local venv was broken)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `tools` parameter for evaluator and judge runner functions
  * Introduced new preset evaluators: `Tool_Selection` and `Knowledge_Retention`
  * Enhanced multi-turn conversations with `tool_calls` support and new `tool` role

* **Chores**
  * Python SDK updated to v1.11.0
  * TypeScript SDK updated to v0.10.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/root-signals/scorable-sdk/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->