### PR TITLE
CLI 0.13.0: tool-call multi-turn shape and --tools flag

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.13.0
+
+- Bump `@root-signals/scorable` to `^0.10.0` for the new tool-call multi-turn shape.
+- `--turns` now accepts the structured tool-call shape: nullable `content`, assistant `tool_calls`, and a `tool` role with `tool_call_id`. Previously turns with `content: null` were rejected.
+- Add `--tools <json>` flag to `evaluator execute`, `evaluator execute-by-name`, `judge execute`, and `judge execute-by-name` for passing an OpenAI-style tool catalog.
+- Help text updated with a tool-aware evaluation example for each command.
+
 ## 0.12.0
 
 - Add `--api-url <url>` global flag to override the API base URL (on-prem deployments; also overridable via `SCORABLE_API_URL` env var)

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.10.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@root-signals/scorable-cli",
-      "version": "0.10.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@root-signals/scorable": "^0.8.0",
+        "@root-signals/scorable": "^0.10.0",
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
@@ -1379,9 +1379,9 @@
       "license": "MIT"
     },
     "node_modules/@root-signals/scorable": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.8.0.tgz",
-      "integrity": "sha512-GmIgtczcfuAUGXG0VRsPJSgsTbxkZwzpqq5/XJD3Ltfl9iWtFDnIiiT9kKbnXNoq4fs7sEbyyL1eg9nACaIt5Q==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.10.0.tgz",
+      "integrity": "sha512-W9+vX5WPkhP3XxwgPdAe9I+6At0diHi3xPYrc7xvUFD54UZCj2+SAVPtGRZPbXrk6jdAY+/+6/iaIPGYkRJ3Aw==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.15.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",
-    "@root-signals/scorable": "^0.8.0",
+    "@root-signals/scorable": "^0.10.0",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",

--- a/cli/src/commands/evaluator/create.ts
+++ b/cli/src/commands/evaluator/create.ts
@@ -65,7 +65,9 @@ export function registerCreateCommand(evaluator: Command): void {
         if (opts.models) {
           const r = parseJsonArg(opts.models, z.array(z.string()));
           if (!r.ok) {
-            printError("Invalid JSON format for --models. Expected an array of model name strings.");
+            printError(
+              "Invalid JSON format for --models. Expected an array of model name strings.",
+            );
             return;
           }
           payload.models = r.value;

--- a/cli/src/commands/evaluator/create.ts
+++ b/cli/src/commands/evaluator/create.ts
@@ -1,7 +1,9 @@
 import { Command } from "commander";
 import ora from "ora";
+import { z } from "zod";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
+import { parseJsonArg } from "../../utils.js";
 import type { EvaluatorCreateParams } from "@root-signals/scorable";
 
 export function registerCreateCommand(evaluator: Command): void {
@@ -61,12 +63,12 @@ export function registerCreateCommand(evaluator: Command): void {
         if (opts.objectiveVersionId) payload.objective_version_id = opts.objectiveVersionId;
 
         if (opts.models) {
-          try {
-            payload.models = JSON.parse(opts.models) as string[];
-          } catch {
-            printError("Invalid JSON format for --models.");
+          const r = parseJsonArg(opts.models, z.array(z.string()));
+          if (!r.ok) {
+            printError("Invalid JSON format for --models. Expected an array of model name strings.");
             return;
           }
+          payload.models = r.value;
         }
 
         const spinner = ora("Creating...").start();

--- a/cli/src/commands/evaluator/execute-by-name.ts
+++ b/cli/src/commands/evaluator/execute-by-name.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
-import { isTurnArray, isStringArray, isStringRecord } from "../../utils.js";
+import { isTurnArray, isToolCatalog, isStringArray, isStringRecord } from "../../utils.js";
 import type { ExecutionPayload } from "@root-signals/scorable";
 
 async function readStdinDefault(): Promise<string> {
@@ -17,6 +17,7 @@ export async function executeEvaluatorByName(
     request?: string;
     response?: string;
     turns?: string;
+    tools?: string;
     contexts?: string;
     expectedOutput?: string;
     tag?: string[];
@@ -58,6 +59,20 @@ export async function executeEvaluatorByName(
       payload.turns = parsed;
     } catch {
       printError("Invalid JSON for --turns.");
+      return;
+    }
+  }
+
+  if (opts.tools) {
+    try {
+      const parsed: unknown = JSON.parse(opts.tools);
+      if (!isToolCatalog(parsed)) {
+        printError("Invalid JSON for --tools. Expected array of tool objects.");
+        return;
+      }
+      payload.tools = parsed;
+    } catch {
+      printError("Invalid JSON for --tools.");
       return;
     }
   }
@@ -122,8 +137,9 @@ export function registerExecuteByNameCommand(evaluator: Command): void {
     .option("--system-prompt <text>", "System prompt that was used for the LLM call")
     .option(
       "--turns <json>",
-      'JSON array of conversation turns. E.g., \'[{"role":"user","content":"Hello"}]\'',
+      'JSON array of conversation turns. Roles: user|assistant|tool. Assistant turns may carry `tool_calls`; tool results use a `tool` role with `tool_call_id`. E.g., \'[{"role":"user","content":"Hello"}]\'',
     )
+    .option("--tools <json>", "JSON array of OpenAI-style tool definitions available to the agent.")
     .option(
       "--variables <json>",
       'JSON object of extra template variables. E.g., \'{"lang":"EN"}\'',
@@ -152,6 +168,11 @@ Examples:
   $ scorable evaluator execute-by-name "Helpfulness" \\
       --turns '[{"role":"user","content":"Hello, I need help with my order"},{"role":"assistant","content":"I\\'d be happy to help! What\\'s your order number?"},{"role":"user","content":"It\\'s ORDER-12345"}]'
 
+  # Tool-aware evaluation: assistant tool_calls + tool-role result + tool catalog
+  $ scorable evaluator execute-by-name "Tool Selection" \\
+      --turns '[{"role":"user","content":"What is the weather in Paris?"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\\"city\\":\\"Paris\\"}"}}]},{"role":"tool","tool_call_id":"call_1","content":"{\\"temp\\":12}"},{"role":"assistant","content":"It is 12C in Paris."}]' \\
+      --tools '[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}}}}}]'
+
   # Pipe a response from your app via stdin
   $ ./my-app respond "Do you offer refunds?" | \\
       scorable evaluator execute-by-name "Helpfulness" --request "Do you offer refunds?"`,
@@ -163,6 +184,7 @@ Examples:
           request?: string;
           response?: string;
           turns?: string;
+          tools?: string;
           contexts?: string;
           expectedOutput?: string;
           tag: string[];

--- a/cli/src/commands/evaluator/execute.ts
+++ b/cli/src/commands/evaluator/execute.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
-import { isTurnArray, isStringArray, isStringRecord } from "../../utils.js";
+import { isTurnArray, isToolCatalog, isStringArray, isStringRecord } from "../../utils.js";
 import type { ExecutionPayload } from "@root-signals/scorable";
 
 async function readStdinDefault(): Promise<string> {
@@ -17,6 +17,7 @@ export async function executeEvaluator(
     request?: string;
     response?: string;
     turns?: string;
+    tools?: string;
     contexts?: string;
     expectedOutput?: string;
     tag?: string[];
@@ -59,6 +60,20 @@ export async function executeEvaluator(
       payload.turns = parsed;
     } catch {
       printError("Invalid JSON for --turns.");
+      return;
+    }
+  }
+
+  if (opts.tools) {
+    try {
+      const parsed: unknown = JSON.parse(opts.tools);
+      if (!isToolCatalog(parsed)) {
+        printError("Invalid JSON for --tools. Expected array of tool objects.");
+        return;
+      }
+      payload.tools = parsed;
+    } catch {
+      printError("Invalid JSON for --tools.");
       return;
     }
   }
@@ -136,8 +151,9 @@ export function registerExecuteCommand(evaluator: Command): void {
     .option("--system-prompt <text>", "System prompt that was used for the LLM call")
     .option(
       "--turns <json>",
-      'JSON array of conversation turns. E.g., \'[{"role":"user","content":"Hello"}]\'',
+      'JSON array of conversation turns. Roles: user|assistant|tool. Assistant turns may carry `tool_calls`; tool results use a `tool` role with `tool_call_id`. E.g., \'[{"role":"user","content":"Hello"}]\'',
     )
+    .option("--tools <json>", "JSON array of OpenAI-style tool definitions available to the agent.")
     .option(
       "--variables <json>",
       'JSON object of extra template variables. E.g., \'{"lang":"EN"}\'',
@@ -171,6 +187,11 @@ Examples:
   $ scorable evaluator execute <evaluatorId> \\
       --turns '[{"role":"user","content":"Hello, I need help with my order"},{"role":"assistant","content":"I\\'d be happy to help! What\\'s your order number?"},{"role":"user","content":"It\\'s ORDER-12345"},{"role":"assistant","content":"I found your order. It\\'s currently in transit."}]'
 
+  # Tool-aware evaluation: assistant tool_calls, tool-role result, and tool catalog
+  $ scorable evaluator execute <evaluatorId> \\
+      --turns '[{"role":"user","content":"What is the weather in Paris?"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\\"city\\":\\"Paris\\"}"}}]},{"role":"tool","tool_call_id":"call_1","content":"{\\"temp\\":12}"},{"role":"assistant","content":"It is 12C in Paris."}]' \\
+      --tools '[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}}}}}]'
+
   # With custom template variables and tracking
   $ scorable evaluator execute <evaluatorId> \\
       --request "How do I cancel my subscription?" \\
@@ -191,6 +212,7 @@ Examples:
           request?: string;
           response?: string;
           turns?: string;
+          tools?: string;
           contexts?: string;
           expectedOutput?: string;
           tag: string[];

--- a/cli/src/commands/evaluator/update.ts
+++ b/cli/src/commands/evaluator/update.ts
@@ -1,7 +1,9 @@
 import { Command } from "commander";
 import ora from "ora";
+import { z } from "zod";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printInfo, printSuccess, printError, printJson, handleSdkError } from "../../output.js";
+import { parseJsonArg } from "../../utils.js";
 import type { EvaluatorUpdateParams } from "@root-signals/scorable";
 
 export function registerUpdateCommand(evaluator: Command): void {
@@ -34,12 +36,12 @@ export function registerUpdateCommand(evaluator: Command): void {
           payload.objective_version_id = opts.objectiveVersionId;
 
         if (opts.models !== undefined) {
-          try {
-            payload.models = JSON.parse(opts.models) as string[];
-          } catch {
-            printError("Invalid JSON format for --models.");
+          const r = parseJsonArg(opts.models, z.array(z.string()));
+          if (!r.ok) {
+            printError("Invalid JSON format for --models. Expected an array of model name strings.");
             return;
           }
+          payload.models = r.value;
         }
 
         if (Object.keys(payload).length === 0) {

--- a/cli/src/commands/evaluator/update.ts
+++ b/cli/src/commands/evaluator/update.ts
@@ -38,7 +38,9 @@ export function registerUpdateCommand(evaluator: Command): void {
         if (opts.models !== undefined) {
           const r = parseJsonArg(opts.models, z.array(z.string()));
           if (!r.ok) {
-            printError("Invalid JSON format for --models. Expected an array of model name strings.");
+            printError(
+              "Invalid JSON format for --models. Expected an array of model name strings.",
+            );
             return;
           }
           payload.models = r.value;

--- a/cli/src/commands/judge/create.ts
+++ b/cli/src/commands/judge/create.ts
@@ -1,8 +1,12 @@
 import { Command } from "commander";
 import ora from "ora";
+import { z } from "zod";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
+import { parseJsonArg } from "../../utils.js";
 import type { CreateJudgeData } from "@root-signals/scorable";
+
+const EvaluatorRefsSchema = z.array(z.object({ id: z.string() }).passthrough());
 
 export function registerCreateCommand(judge: Command): void {
   judge
@@ -28,14 +32,14 @@ export function registerCreateCommand(judge: Command): void {
         if (opts.stage) payload.stage = opts.stage;
 
         if (opts.evaluatorReferences) {
-          try {
-            payload.evaluator_references = JSON.parse(opts.evaluatorReferences) as Array<{
-              id: string;
-            }>;
-          } catch {
-            printError("Invalid JSON format for --evaluator-references.");
+          const r = parseJsonArg(opts.evaluatorReferences, EvaluatorRefsSchema);
+          if (!r.ok) {
+            printError(
+              'Invalid JSON format for --evaluator-references. Expected an array of objects with an "id" string.',
+            );
             return;
           }
+          payload.evaluator_references = r.value;
         }
 
         const spinner = ora("Creating...").start();

--- a/cli/src/commands/judge/exec-openai-generic.ts
+++ b/cli/src/commands/judge/exec-openai-generic.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { z } from "zod";
 import { requireApiKey } from "../../auth.js";
 import {
   printInfo,
@@ -8,7 +9,11 @@ import {
   printJson,
   handleSdkError,
 } from "../../output.js";
+import { parseJsonArg } from "../../utils.js";
 import { apiRequest } from "../../client.js";
+
+const MessagesSchema = z.array(z.object({ role: z.string() }).passthrough());
+const ExtraBodySchema = z.record(z.string(), z.unknown());
 
 export function registerExecOpenaiGenericCommand(judge: Command): void {
   judge
@@ -20,21 +25,25 @@ export function registerExecOpenaiGenericCommand(judge: Command): void {
     .action(async (opts: { model: string; messages: string; extraBody?: string }) => {
       const apiKey = await requireApiKey();
 
-      let messages: unknown;
-      try {
-        messages = JSON.parse(opts.messages);
-      } catch {
-        printError("Invalid JSON for --messages. Aborting.");
+      const messagesResult = parseJsonArg(opts.messages, MessagesSchema);
+      if (!messagesResult.ok) {
+        printError(
+          "Invalid JSON for --messages. Expected an array of objects each with a string `role`. Aborting.",
+        );
         return;
       }
 
-      const payload: Record<string, unknown> = { model: opts.model, messages };
+      const payload: Record<string, unknown> = {
+        model: opts.model,
+        messages: messagesResult.value,
+      };
 
       if (opts.extraBody) {
-        try {
-          payload["extra_body"] = JSON.parse(opts.extraBody);
-        } catch {
-          printWarning("Invalid JSON for --extra-body. Skipping.");
+        const extraResult = parseJsonArg(opts.extraBody, ExtraBodySchema);
+        if (extraResult.ok) {
+          payload["extra_body"] = extraResult.value;
+        } else {
+          printWarning("Invalid JSON for --extra-body (expected an object). Skipping.");
         }
       }
 

--- a/cli/src/commands/judge/exec-openai.ts
+++ b/cli/src/commands/judge/exec-openai.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { z } from "zod";
 import { requireApiKey } from "../../auth.js";
 import {
   printInfo,
@@ -8,7 +9,11 @@ import {
   printJson,
   handleSdkError,
 } from "../../output.js";
+import { parseJsonArg } from "../../utils.js";
 import { apiRequest } from "../../client.js";
+
+const MessagesSchema = z.array(z.object({ role: z.string() }).passthrough());
+const ExtraBodySchema = z.record(z.string(), z.unknown());
 
 export function registerExecOpenaiCommand(judge: Command): void {
   judge
@@ -24,21 +29,25 @@ export function registerExecOpenaiCommand(judge: Command): void {
       ) => {
         const apiKey = await requireApiKey();
 
-        let messages: unknown;
-        try {
-          messages = JSON.parse(opts.messages);
-        } catch {
-          printError("Invalid JSON for --messages. Aborting.");
+        const messagesResult = parseJsonArg(opts.messages, MessagesSchema);
+        if (!messagesResult.ok) {
+          printError(
+            "Invalid JSON for --messages. Expected an array of objects each with a string `role`. Aborting.",
+          );
           return;
         }
 
-        const payload: Record<string, unknown> = { model: opts.model, messages };
+        const payload: Record<string, unknown> = {
+          model: opts.model,
+          messages: messagesResult.value,
+        };
 
         if (opts.extraBody) {
-          try {
-            payload["extra_body"] = JSON.parse(opts.extraBody);
-          } catch {
-            printWarning("Invalid JSON for --extra-body. Skipping.");
+          const extraResult = parseJsonArg(opts.extraBody, ExtraBodySchema);
+          if (extraResult.ok) {
+            payload["extra_body"] = extraResult.value;
+          } else {
+            printWarning("Invalid JSON for --extra-body (expected an object). Skipping.");
           }
         }
 

--- a/cli/src/commands/judge/execute-by-name.ts
+++ b/cli/src/commands/judge/execute-by-name.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
-import { isTurnArray, isStringArray } from "../../utils.js";
+import { isTurnArray, isToolCatalog, isStringArray } from "../../utils.js";
 import type { JudgeExecutionPayload } from "@root-signals/scorable";
 
 async function readStdinDefault(): Promise<string> {
@@ -17,6 +17,7 @@ export async function executeJudgeByName(
     request?: string;
     response?: string;
     turns?: string;
+    tools?: string;
     contexts?: string;
     expectedOutput?: string;
     tag?: string[];
@@ -57,6 +58,20 @@ export async function executeJudgeByName(
       payload.turns = parsed;
     } catch {
       printError("Invalid JSON for --turns.");
+      return;
+    }
+  }
+
+  if (opts.tools) {
+    try {
+      const parsed: unknown = JSON.parse(opts.tools);
+      if (!isToolCatalog(parsed)) {
+        printError("Invalid JSON for --tools. Expected array of tool objects.");
+        return;
+      }
+      payload.tools = parsed;
+    } catch {
+      printError("Invalid JSON for --tools.");
       return;
     }
   }
@@ -107,8 +122,9 @@ export function registerExecuteByNameCommand(judge: Command): void {
     .option("--system-prompt <text>", "System prompt that was used for the LLM call")
     .option(
       "--turns <json>",
-      'JSON array of conversation turns. E.g., \'[{"role":"user","content":"Hello"}]\'',
+      'JSON array of conversation turns. Roles: user|assistant|tool. Assistant turns may carry `tool_calls`; tool results use a `tool` role with `tool_call_id`. E.g., \'[{"role":"user","content":"Hello"}]\'',
     )
+    .option("--tools <json>", "JSON array of OpenAI-style tool definitions available to the agent.")
     .addHelpText(
       "after",
       `
@@ -128,6 +144,11 @@ Examples:
   $ scorable judge execute-by-name "Customer Service Judge" \\
       --turns '[{"role":"user","content":"I haven\\'t received my refund and it\\'s been 10 days."},{"role":"assistant","content":"Thank you for contacting us. I will investigate this immediately and provide an update within 24 hours."}]'
 
+  # Tool-aware evaluation: assistant tool_calls + tool-role result + tool catalog
+  $ scorable judge execute-by-name "Agent Quality Judge" \\
+      --turns '[{"role":"user","content":"What is the weather in Paris?"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\\"city\\":\\"Paris\\"}"}}]},{"role":"tool","tool_call_id":"call_1","content":"{\\"temp\\":12}"},{"role":"assistant","content":"It is 12C in Paris."}]' \\
+      --tools '[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}}}}}]'
+
   # Pipe the LLM response from stdin
   $ echo "We offer a 30-day money-back guarantee on all purchases." | \\
       scorable judge execute-by-name "Custom Returns Policy Judge" --request "Do you offer refunds?"`,
@@ -139,6 +160,7 @@ Examples:
           request?: string;
           response?: string;
           turns?: string;
+          tools?: string;
           contexts?: string;
           expectedOutput?: string;
           tag: string[];

--- a/cli/src/commands/judge/execute.ts
+++ b/cli/src/commands/judge/execute.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
-import { isTurnArray, isStringArray } from "../../utils.js";
+import { isTurnArray, isToolCatalog, isStringArray } from "../../utils.js";
 import type { JudgeExecutionPayload } from "@root-signals/scorable";
 
 async function readStdinDefault(): Promise<string> {
@@ -17,6 +17,7 @@ export async function executeJudge(
     request?: string;
     response?: string;
     turns?: string;
+    tools?: string;
     contexts?: string;
     expectedOutput?: string;
     tag?: string[];
@@ -57,6 +58,20 @@ export async function executeJudge(
       payload.turns = parsed;
     } catch {
       printError("Invalid JSON for --turns.");
+      return;
+    }
+  }
+
+  if (opts.tools) {
+    try {
+      const parsed: unknown = JSON.parse(opts.tools);
+      if (!isToolCatalog(parsed)) {
+        printError("Invalid JSON for --tools. Expected array of tool objects.");
+        return;
+      }
+      payload.tools = parsed;
+    } catch {
+      printError("Invalid JSON for --tools.");
       return;
     }
   }
@@ -107,8 +122,9 @@ export function registerExecuteCommand(judge: Command): void {
     .option("--system-prompt <text>", "System prompt that was used for the LLM call")
     .option(
       "--turns <json>",
-      'JSON array of conversation turns. E.g., \'[{"role":"user","content":"Hello"}]\'',
+      'JSON array of conversation turns. Roles: user|assistant|tool. Assistant turns may carry `tool_calls`; tool results use a `tool` role with `tool_call_id`. E.g., \'[{"role":"user","content":"Hello"}]\'',
     )
+    .option("--tools <json>", "JSON array of OpenAI-style tool definitions available to the agent.")
     .addHelpText(
       "after",
       `
@@ -128,6 +144,11 @@ Examples:
   $ scorable judge execute <judgeId> \\
       --turns '[{"role":"user","content":"Hello, I need help with my order"},{"role":"assistant","content":"I\\'d be happy to help! What\\'s your order number?"},{"role":"user","content":"It\\'s ORDER-12345"},{"role":"assistant","content":"I found your order. It\\'s currently in transit."}]'
 
+  # Tool-aware evaluation: assistant tool_calls, tool-role result, and tool catalog
+  $ scorable judge execute <judgeId> \\
+      --turns '[{"role":"user","content":"What is the weather in Paris?"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\\"city\\":\\"Paris\\"}"}}]},{"role":"tool","tool_call_id":"call_1","content":"{\\"temp\\":12}"},{"role":"assistant","content":"It is 12C in Paris."}]' \\
+      --tools '[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}}}}}]'
+
   # With tracking metadata and tags
   $ scorable judge execute <judgeId> \\
       --request "How do I reset my password?" \\
@@ -146,6 +167,7 @@ Examples:
           request?: string;
           response?: string;
           turns?: string;
+          tools?: string;
           contexts?: string;
           expectedOutput?: string;
           tag: string[];

--- a/cli/src/commands/judge/generate.ts
+++ b/cli/src/commands/judge/generate.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import ora from "ora";
 import chalk from "chalk";
+import { z } from "zod";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import {
   printSuccess,
@@ -10,6 +11,7 @@ import {
   printJson,
   handleSdkError,
 } from "../../output.js";
+import { parseJsonArg } from "../../utils.js";
 import { CliError } from "../../types.js";
 import { uploadFile } from "../file/upload.js";
 
@@ -80,12 +82,12 @@ offer to connect the guest with a human agent when uncertain."`,
 
         let extra_contexts: Record<string, string> | undefined;
         if (opts.extraContexts) {
-          try {
-            extra_contexts = JSON.parse(opts.extraContexts) as Record<string, string>;
-          } catch {
+          const r = parseJsonArg(opts.extraContexts, z.record(z.string(), z.string()));
+          if (!r.ok) {
             printError("Invalid --extra-contexts JSON: must be a key-value object.");
             throw new CliError(1, "Invalid extra-contexts JSON");
           }
+          extra_contexts = r.value;
         }
 
         const spinner = ora("Generating judge (this may take a moment)...").start();

--- a/cli/src/commands/judge/update.ts
+++ b/cli/src/commands/judge/update.ts
@@ -1,8 +1,12 @@
 import { Command } from "commander";
 import ora from "ora";
+import { z } from "zod";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printInfo, printSuccess, printError, printJson, handleSdkError } from "../../output.js";
+import { parseJsonArg } from "../../utils.js";
 import type { UpdateJudgeData } from "@root-signals/scorable";
+
+const EvaluatorRefsSchema = z.array(z.object({ id: z.string() }).passthrough());
 
 export function registerUpdateCommand(judge: Command): void {
   judge
@@ -26,14 +30,14 @@ export function registerUpdateCommand(judge: Command): void {
         if (opts.stage !== undefined) payload.stage = opts.stage;
 
         if (opts.evaluatorReferences !== undefined) {
-          try {
-            payload.evaluator_references = JSON.parse(opts.evaluatorReferences) as Array<{
-              id: string;
-            }>;
-          } catch {
-            printError("Invalid JSON format for --evaluator-references.");
+          const r = parseJsonArg(opts.evaluatorReferences, EvaluatorRefsSchema);
+          if (!r.ok) {
+            printError(
+              'Invalid JSON format for --evaluator-references. Expected an array of objects with an "id" string.',
+            );
             return;
           }
+          payload.evaluator_references = r.value;
         }
 
         if (Object.keys(payload).length === 0) {

--- a/cli/src/commands/otel-filter/create.ts
+++ b/cli/src/commands/otel-filter/create.ts
@@ -4,7 +4,8 @@ import ora from "ora";
 import { requireApiKey } from "../../auth.js";
 import { apiRequest } from "../../client.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
-import { loadFilterYaml } from "../../lib/filter-yaml.js";
+import { loadFilterYaml, Match } from "../../lib/filter-yaml.js";
+import { parseJsonArg } from "../../utils.js";
 
 interface CreateOptions {
   name?: string;
@@ -100,12 +101,14 @@ YAML manifest (only needed for custom extractor_rules):
 
       let filterCriteria: Record<string, unknown> | undefined;
       if (opts.filterCriteria) {
-        try {
-          filterCriteria = JSON.parse(opts.filterCriteria) as Record<string, unknown>;
-        } catch {
-          printError("Invalid JSON for --filter-criteria.");
+        const r = parseJsonArg(opts.filterCriteria, Match);
+        if (!r.ok) {
+          printError(
+            'Invalid JSON for --filter-criteria. Expected {"conditions":[{column,operator,value?,key?},...]}.',
+          );
           process.exit(1);
         }
+        filterCriteria = r.value;
       }
 
       let samplingRate: number | undefined;

--- a/cli/src/lib/filter-yaml.ts
+++ b/cli/src/lib/filter-yaml.ts
@@ -10,7 +10,7 @@ const MatchCondition = z
   })
   .strict();
 
-const Match = z
+export const Match = z
   .object({
     conditions: z.array(MatchCondition).default([]),
   })

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -2,7 +2,7 @@ import { z, type ZodType } from "zod";
 import type { Turn } from "@root-signals/scorable";
 
 const TurnSchema = z.object({
-  role: z.enum(["user", "assistant", "tool", "system"]),
+  role: z.enum(["user", "assistant", "tool"]),
   content: z.string().nullable().optional(),
   contexts: z.array(z.string()).nullable().optional(),
   tool_calls: z.array(z.record(z.string(), z.unknown())).nullable().optional(),

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1,18 +1,23 @@
+import { z } from "zod";
 import type { Turn } from "@root-signals/scorable";
 
+const TurnSchema = z.object({
+  role: z.enum(["user", "assistant", "tool", "system"]),
+  content: z.string().nullable().optional(),
+  contexts: z.array(z.string()).nullable().optional(),
+  tool_calls: z.array(z.record(z.string(), z.unknown())).nullable().optional(),
+  tool_call_id: z.string().nullable().optional(),
+});
+
+const TurnArraySchema = z.array(TurnSchema);
+const ToolCatalogSchema = z.array(z.record(z.string(), z.unknown()));
+
 export function isTurnArray(v: unknown): v is Turn[] {
-  return (
-    Array.isArray(v) &&
-    v.every(
-      (t) =>
-        typeof t === "object" &&
-        t !== null &&
-        "role" in t &&
-        typeof (t as Record<string, unknown>).role === "string" &&
-        "content" in t &&
-        typeof (t as Record<string, unknown>).content === "string",
-    )
-  );
+  return TurnArraySchema.safeParse(v).success;
+}
+
+export function isToolCatalog(v: unknown): v is Record<string, unknown>[] {
+  return ToolCatalogSchema.safeParse(v).success;
 }
 
 export function isStringArray(v: unknown): v is string[] {

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z, type ZodType } from "zod";
 import type { Turn } from "@root-signals/scorable";
 
 const TurnSchema = z.object({
@@ -31,4 +31,20 @@ export function isStringRecord(v: unknown): v is Record<string, string> {
     !Array.isArray(v) &&
     Object.values(v as Record<string, unknown>).every((val) => typeof val === "string")
   );
+}
+
+// Parse a JSON-string CLI argument and validate it against a zod schema.
+// Callers print their own error message so existing wording stays stable.
+export type JsonArgResult<T> = { ok: true; value: T } | { ok: false };
+
+export function parseJsonArg<T>(raw: string, schema: ZodType<T>): JsonArgResult<T> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false };
+  }
+  const result = schema.safeParse(parsed);
+  if (!result.success) return { ok: false };
+  return { ok: true, value: result.data };
 }

--- a/cli/tests/evaluator.test.ts
+++ b/cli/tests/evaluator.test.ts
@@ -416,7 +416,9 @@ describe("TestEvaluatorExecute", () => {
       "eval-123",
       expect.objectContaining({ turns: expect.any(Array) }),
     );
-    const payload = mockExecute.mock.calls[0]?.[1] as { turns: { role: string; content: string | null }[] };
+    const payload = mockExecute.mock.calls[0]?.[1] as {
+      turns: { role: string; content: string | null }[];
+    };
     expect(payload.turns[1]?.content).toBeNull();
     expect(payload.turns[2]?.role).toBe("tool");
   });

--- a/cli/tests/evaluator.test.ts
+++ b/cli/tests/evaluator.test.ts
@@ -383,6 +383,78 @@ describe("TestEvaluatorExecute", () => {
     expect(result.stderr).toContain("Invalid JSON for --turns");
   });
 
+  it("test_execute_evaluator_with_tool_call_turns", async () => {
+    mockExecute.mockResolvedValue({ result: "success", score: 0.9 });
+    const turns = JSON.stringify([
+      { role: "user", content: "Weather in Paris?" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "get_weather", arguments: '{"city":"Paris"}' },
+          },
+        ],
+      },
+      { role: "tool", tool_call_id: "call_1", content: '{"temp":12}' },
+      { role: "assistant", content: "It is 12C in Paris." },
+    ]);
+    const result = await runCli(["evaluator", "execute", "eval-123", "--turns", turns]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Evaluator execution successful");
+    expect(mockExecute).toHaveBeenCalledWith(
+      "eval-123",
+      expect.objectContaining({ turns: expect.any(Array) }),
+    );
+    const payload = mockExecute.mock.calls[0]?.[1] as { turns: { role: string; content: string | null }[] };
+    expect(payload.turns[1]?.content).toBeNull();
+    expect(payload.turns[2]?.role).toBe("tool");
+  });
+
+  it("test_execute_evaluator_with_tools_catalog", async () => {
+    mockExecute.mockResolvedValue({ result: "success", score: 0.9 });
+    const tools = JSON.stringify([
+      {
+        type: "function",
+        function: {
+          name: "get_weather",
+          description: "Get weather for a city",
+          parameters: { type: "object", properties: { city: { type: "string" } } },
+        },
+      },
+    ]);
+    const result = await runCli([
+      "evaluator",
+      "execute",
+      "eval-123",
+      "--request",
+      "Weather?",
+      "--tools",
+      tools,
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(mockExecute).toHaveBeenCalledWith(
+      "eval-123",
+      expect.objectContaining({ tools: expect.any(Array) }),
+    );
+  });
+
+  it("test_execute_evaluator_invalid_tools_json", async () => {
+    const result = await runCli([
+      "evaluator",
+      "execute",
+      "eval-123",
+      "--request",
+      "Hi",
+      "--tools",
+      "not-json",
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("Invalid JSON for --tools");
+  });
+
   it("test_execute_evaluator_with_variables", async () => {
     mockExecute.mockResolvedValue({ result: "success", score: 0.9 });
     const result = await runCli([

--- a/cli/tests/evaluator.test.ts
+++ b/cli/tests/evaluator.test.ts
@@ -304,6 +304,14 @@ describe("TestEvaluatorUpdate", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toContain("Invalid JSON format");
   });
+
+  it("rejects --models when the JSON is the wrong shape", async () => {
+    // Valid JSON, wrong shape — must be rejected by the schema, not silently sent.
+    const result = await runCli(["evaluator", "update", "eval-123", "--models", '"foo"']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("Invalid JSON format");
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
 });
 
 // --- TestEvaluatorDelete ---

--- a/cli/tests/judge.test.ts
+++ b/cli/tests/judge.test.ts
@@ -281,6 +281,20 @@ describe("TestJudgeUpdate", () => {
     expect(result.stderr).toContain("Invalid JSON format");
   });
 
+  it("rejects --evaluator-references without an id field", async () => {
+    // Valid JSON, missing the required `id` field — schema must reject.
+    const result = await runCli([
+      "judge",
+      "update",
+      "judge-123",
+      "--evaluator-references",
+      '[{"name":"x"}]',
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("Invalid JSON format");
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("test_update_judge_no_params", async () => {
     const result = await runCli(["judge", "update", "judge-123"]);
     expect(result.exitCode).toBe(0);

--- a/cli/tests/otel-filter.test.ts
+++ b/cli/tests/otel-filter.test.ts
@@ -132,6 +132,22 @@ describe("TestOtelFilterCreate", () => {
     expect(result.stderr).toContain("Invalid JSON");
   });
 
+  it("rejects --filter-criteria when the JSON is not a Match", async () => {
+    // Valid JSON but not a Match — schema must reject the same way the YAML path does.
+    const result = await runCli([
+      "otel-filter",
+      "create",
+      "--name",
+      "x",
+      "--evaluator-id",
+      EVALUATOR_ID,
+      "--filter-criteria",
+      '{"wrong":"shape"}',
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Invalid JSON");
+  });
+
   it("test_create__rejects_sampling_rate_outside_range", async () => {
     const result = await runCli([
       "otel-filter",


### PR DESCRIPTION
## Summary

Brings the CLI up to date with the OpenAI-shape tool catalog and structured `tool_calls` multi-turn support introduced in #127 and shipped in scorable SDKs 1.11.0 / 0.10.0.

### What changed
- Bump `@root-signals/scorable` dep to `^0.10.0`.
- Replace hand-rolled `isTurnArray` in `src/utils.ts` with a zod schema that mirrors `MessageTurnRequest` — nullable `content`, optional `tool_calls`/`tool_call_id`, role enum including `tool`. The previous validator required `content` to be a string, so the new shape was rejected with "Invalid JSON for --turns."
- Add `--tools <json>` to `evaluator execute`, `evaluator execute-by-name`, `judge execute`, `judge execute-by-name`. Validated with a zod schema, attached to `payload.tools`. Used by tool-aware evaluators such as `Tool_Selection`.
- Add a tool-aware example to each command's `--help`.
- Tests: cover the new turn shape and `--tools` (happy path + invalid JSON) on `evaluator execute`.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] `npm run test` — 205 passed (3 new)
- [ ] CI to confirm on green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --tools option to evaluator and judge commands for supplying tool catalogs.

* **Changes**
  * --turns accepts structured tool-call multi-turn shapes and allows nullable content fields.
  * CLI JSON inputs now use schema validation, with clearer, specific error messages for flags like --models, --messages, --extra-body, --evaluator-references, --extra-contexts, and --filter-criteria.

* **Documentation**
  * Help text updated with tool-aware evaluation examples.

* **Tests**
  * Added tests for tool/catalog handling and JSON shape validations.

* **Chores**
  * CLI version bumped to 0.13.0 and dependencies updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/root-signals/scorable-sdk/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->