### PR TITLE
Make judge_multi_turn example re-runnable with a unique judge name

### DIFF
--- a/python/examples/judge_multi_turn.py
+++ b/python/examples/judge_multi_turn.py
@@ -1,3 +1,5 @@
+import uuid
+
 from scorable import Scorable
 from scorable.generated.openapi_client.models.evaluator_reference_request import EvaluatorReferenceRequest
 from scorable.multiturn import Turn
@@ -52,7 +54,10 @@ evaluator_references = [
 ]
 
 judge = client.judges.create(
-    name="Customer Service Judge",
+    # Suffix keeps the example re-runnable: if a previous run created the judge
+    # and a later step failed (e.g. judge.run timeout), retrying with the same
+    # hardcoded name trips the unique-name-per-org constraint.
+    name=f"Customer Service Judge {uuid.uuid4().hex[:8]}",
     intent="Evaluate customer service agent conversations for helpfulness and accuracy",
     evaluator_references=evaluator_references,
 )


### PR DESCRIPTION
The example uses `name="Customer Service Judge"`. If the example fails after the judge is created (e.g. `judge.run` timeout), re-running trips the unique judge-name-per-org constraint with a 400. The rs monorepo's system test runs the example under `pytest-rerunfailures` and consistently hits this flake.

Suffix the name with `uuid.uuid4().hex[:8]` so each run picks a fresh name. The example still reads naturally as 'create a customer-service-style judge' but no longer collides with itself on retry.

(`test_create_judge` has the same pattern but is deselected in the rs monorepo's Makefile — happy to follow up with the same fix on it too if folks want.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the multi-turn judge example to automatically generate unique judge names on each run. This eliminates naming constraint violations when re-executing the example after partial failures like timeouts or temporary network errors, enabling users to iterate and troubleshoot more effectively during development cycles without encountering duplicate name errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->