### PR TITLE
Python SDK 1.11.1

### DIFF
--- a/python/docs/CHANGELOG.md
+++ b/python/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.1
+
+- Fix `tools` parameter not being forwarded by `judges.run`/`arun`/`run_by_name`/`arun_by_name`; the 1.11.0 release exposed `tools` on skills/evaluators only.
+
 ## 1.11.0
 
 - Add `tools` parameter (OpenAI-style tool catalog) to `evaluators.run`/`arun`/`run_by_name`/`arun_by_name`, `judges.run`/`arun`, and preset evaluator runners. Enables tool-aware evaluators like `Tool_Selection`.

--- a/python/src/scorable/__about__.py
+++ b/python/src/scorable/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present juho.ylikyla <juho.ylikyla@scorable.ai>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.11.0"
+__version__ = "1.11.1"


### PR DESCRIPTION
## Summary
- Patch release. Bumps Python SDK to 1.11.1.
- Picks up #141, which fixed `tools` forwarding in `judges.run`/`arun`/`run_by_name`/`arun_by_name` — the 1.11.0 release exposed `tools` on skills/evaluators only, even though the changelog claimed judges too.

## Test plan
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `pytest tests/` — 22 passed
- [ ] CI green before merge
- [ ] After merge: tag `py-v1.11.1` and create GitHub release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing `tools` parameter support in judge operations.

* **Documentation**
  * Updated changelog for version 1.11.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->