### PR TITLE
CLI 0.14.0 — project hierarchy support

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.14.0
+
+- Bump `@root-signals/scorable` to `^0.11.0` for the new `projects` resource and `projectId` support.
+- New `scorable project` command group: `list`, `get`, `create`, `update`, `delete`, `set-default`. `project create` and `project update` accept `--is-default` to promote a project as the org default (the previous default is unset atomically).
+- `project list` appends `(default)` to the default project's name.
+- `--project-id <uuid>` added to every command that creates, executes, lists, or filters a project-scoped resource: `evaluator` (`execute`, `execute-by-name`, `create`, `update`, `duplicate`, `import-yaml`, `list`), `judge` (`execute`, `execute-by-name`, `create`, `update`, `duplicate`, `generate`, `list`, `exec-openai`, `exec-openai-generic`), and `execution-log list`. Pass `--project-id ""` to opt out of an inherited default for a single invocation.
+- OpenAI-compatible commands (`judge exec-openai`, `judge exec-openai-generic`) translate `--project-id` to the `X-Project-Id` HTTP header per request (the OpenAI wire format can't carry it in the body).
+- `--project-id` resolution order: CLI flag → `SCORABLE_PROJECT_ID` env var → `project_id` in `~/.scorable/settings.json` → omitted (backend resolves to org default).
+- New `auth` subcommands for managing the persistent project preference: `auth set-project <uuid>` writes to settings; `auth unset-project` removes it; `auth show-project` prints the resolved project_id and its source. `auth logout` now also clears the saved project_id.
+- New `project_id` column on `evaluator list`, `judge list`, and `execution-log list` output (public resources show an empty cell).
+- `prompt-test init --project-id <uuid>` persists the project into the generated config file. `prompt-test run` reads it from the config; pass `run --project-id` to override per-invocation.
+- `evaluator export-yaml` strips `project_id` from the output so YAML stays portable across organizations.
+- Backend errors (cross-org `project_id`, duplicate project names, clearing the default) surface as a single-line stderr message with the backend's reason verbatim and exit 1.
+
 ## 0.13.0
 
 - Bump `@root-signals/scorable` to `^0.10.0` for the new tool-call multi-turn shape.

--- a/cli/README.md
+++ b/cli/README.md
@@ -78,6 +78,66 @@ export SCORABLE_API_KEY="sk-your-api-key"
 
 The key lookup order is: `SCORABLE_API_KEY` env var → `api_key` in `~/.scorable/settings.json` → `temporary_api_key` in `~/.scorable/settings.json`.
 
+## Projects
+
+A **project** is a workspace inside your organization that groups related judges, evaluators, datasets, and execution logs. Every resource belongs to a project; omitting the project at create/execute time files things under the org's default project.
+
+### Manage projects
+
+```bash
+scorable project list                                   # list all projects (default marked)
+scorable project get <project_id>                       # show a single project
+scorable project create --name "Production"             # create a project
+scorable project create --name "Production" --is-default
+scorable project update <project_id> --name "Renamed"
+scorable project update <project_id> --is-default       # promote to default
+scorable project set-default <project_id>               # convenience for `update --is-default`
+scorable project delete <project_id>
+```
+
+### `--project-id` on every project-aware command
+
+Every command that creates, executes, lists, or filters a project-scoped resource accepts `--project-id <uuid>`:
+
+```bash
+# Filter list endpoints
+scorable judge list --project-id <project_id>
+scorable evaluator list --project-id <project_id>
+scorable execution-log list --project-id <project_id>
+
+# Route an execution log to a project
+scorable judge execute <judge_id> --project-id <project_id>
+scorable evaluator execute <evaluator_id> --project-id <project_id>
+
+# Pin a resource to a project at creation
+scorable judge create --name X --intent Y --project-id <project_id>
+scorable evaluator import-yaml --file evaluator.yaml --project-id <project_id>
+
+# Move a resource between projects
+scorable judge update <judge_id> --project-id <other_project_id>
+
+# OpenAI-compat (translated to X-Project-Id header)
+scorable judge exec-openai <judge_id> --project-id <project_id>
+```
+
+### Setting a default project for your shell
+
+To avoid passing `--project-id` on every command, set an env var or persist a per-machine default:
+
+```bash
+# Environment variable (great for CI)
+export SCORABLE_PROJECT_ID=<project_id>
+
+# Persistent default written to ~/.scorable/settings.json
+scorable auth set-project <project_id>
+scorable auth show-project    # see what's resolved and from where
+scorable auth unset-project   # remove the saved default
+```
+
+Resolution order: `--project-id` flag → `SCORABLE_PROJECT_ID` env var → `project_id` in `~/.scorable/settings.json` → omitted (backend resolves to org default). Pass `--project-id ""` to explicitly opt out of an inherited default for a single invocation.
+
+`scorable auth logout` clears the entire auth section of `~/.scorable/settings.json`, including the saved project_id.
+
 ## Scorable Skills for AI Coding Agents
 
 Install Scorable skills into your project so your AI coding agent (Claude Code, Cursor, etc.) can integrate evaluators automatically:

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@root-signals/scorable": "^0.10.0",
+        "@root-signals/scorable": "^0.11.0",
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "commander": "^15.0.0",
@@ -1379,9 +1379,9 @@
       "license": "MIT"
     },
     "node_modules/@root-signals/scorable": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.10.0.tgz",
-      "integrity": "sha512-W9+vX5WPkhP3XxwgPdAe9I+6At0diHi3xPYrc7xvUFD54UZCj2+SAVPtGRZPbXrk6jdAY+/+6/iaIPGYkRJ3Aw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.11.0.tgz",
+      "integrity": "sha512-DuGI39YHi2ZOO5kRYgvJbvsBNxBS642Pkg2rNq0sz3mSdhJvCvr3nlrzMkNK0NVPMOSy5oDoExVzG8HVPNGiTw==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.15.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",

--- a/cli/package.json
+++ b/cli/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",
-    "@root-signals/scorable": "^0.10.0",
+    "@root-signals/scorable": "^0.11.0",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^15.0.0",

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -11,6 +11,7 @@ interface RequestOptions {
   params?: Record<string, unknown>;
   apiKey?: string;
   baseUrl?: string;
+  headers?: Record<string, string>;
 }
 
 export interface ApiRequestResult {
@@ -49,6 +50,7 @@ export async function apiRequestStatus(
     "Content-Type": "application/json",
     Accept: "application/json",
     "User-Agent": `scorable/${version}`,
+    ...options?.headers,
   };
 
   let response: Response;

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -46,11 +46,11 @@ export async function apiRequestStatus(
   }
 
   const headers: Record<string, string> = {
+    ...options?.headers,
     Authorization: `Api-Key ${apiKey}`,
     "Content-Type": "application/json",
     Accept: "application/json",
     "User-Agent": `scorable/${version}`,
-    ...options?.headers,
   };
 
   let response: Response;

--- a/cli/src/commands/auth/index.ts
+++ b/cli/src/commands/auth/index.ts
@@ -1,8 +1,12 @@
 import { Command } from "commander";
 import ora from "ora";
 import { loadSettings, saveSettings, createDemoKey } from "../../auth.js";
-import { printSuccess, printError } from "../../output.js";
+import { printSuccess, printError, printInfo, printMessage } from "../../output.js";
+import { resolveProjectId } from "../../lib/project-id.js";
 import { CliError } from "../../types.js";
+
+// Keys owned by the auth surface that `auth logout` clears.
+const AUTH_SETTINGS_KEYS = ["api_key", "temporary_api_key", "project_id"] as const;
 
 export function registerAuthCommands(program: Command): void {
   const auth = program.command("auth").description("Manage authentication");
@@ -42,6 +46,76 @@ export function registerAuthCommands(program: Command): void {
         throw new CliError(1, "Failed to save API key");
       }
       printSuccess("API key saved to ~/.scorable/settings.json");
+    });
+
+  auth
+    .command("set-project <projectId>")
+    .description("Persist a project_id to ~/.scorable/settings.json")
+    .action((projectId: string) => {
+      if (!projectId.trim()) {
+        printError("Project ID must not be empty.");
+        throw new CliError(1, "Empty project id");
+      }
+      const settings = loadSettings();
+      settings["project_id"] = projectId.trim();
+      if (!saveSettings(settings)) {
+        printError("Failed to save project_id to ~/.scorable/settings.json");
+        throw new CliError(1, "Failed to save project_id");
+      }
+      printSuccess(`project_id saved to ~/.scorable/settings.json`);
+    });
+
+  auth
+    .command("unset-project")
+    .description("Remove the persisted project_id from ~/.scorable/settings.json")
+    .action(() => {
+      const settings = loadSettings();
+      if (!("project_id" in settings)) {
+        printInfo("No project_id was set.");
+        return;
+      }
+      delete settings["project_id"];
+      if (!saveSettings(settings)) {
+        printError("Failed to update ~/.scorable/settings.json");
+        throw new CliError(1, "Failed to update settings");
+      }
+      printSuccess("project_id removed from ~/.scorable/settings.json");
+    });
+
+  auth
+    .command("show-project")
+    .description("Print the resolved project_id and its source (flag/env/settings/none)")
+    .action(() => {
+      // No flag value here — flag resolution is per-invocation on other commands.
+      const resolved = resolveProjectId(undefined);
+      if (resolved.value === undefined) {
+        printMessage("project_id: <none> (source: none)");
+        return;
+      }
+      printMessage(`project_id: ${resolved.value} (source: ${resolved.source})`);
+    });
+
+  auth
+    .command("logout")
+    .description("Clear the auth section of ~/.scorable/settings.json (api keys + project_id)")
+    .action(() => {
+      const settings = loadSettings();
+      let touched = false;
+      for (const k of AUTH_SETTINGS_KEYS) {
+        if (k in settings) {
+          delete settings[k];
+          touched = true;
+        }
+      }
+      if (!touched) {
+        printInfo("Already logged out.");
+        return;
+      }
+      if (!saveSettings(settings)) {
+        printError("Failed to update ~/.scorable/settings.json");
+        throw new CliError(1, "Failed to update settings");
+      }
+      printSuccess("Logged out — cleared api_key, temporary_api_key, and project_id.");
     });
 
   auth

--- a/cli/src/commands/evaluator/create.ts
+++ b/cli/src/commands/evaluator/create.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
 import { parseJsonArg } from "../../utils.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import type { EvaluatorCreateParams } from "@root-signals/scorable";
 
 export function registerCreateCommand(evaluator: Command): void {
@@ -26,6 +27,7 @@ export function registerCreateCommand(evaluator: Command): void {
     )
     .option("--overwrite", "Overwrite if evaluator with same name exists")
     .option("--objective-version-id <id>", "Objective version ID")
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
     .action(
       async (opts: {
         name: string;
@@ -35,6 +37,7 @@ export function registerCreateCommand(evaluator: Command): void {
         models?: string;
         overwrite?: boolean;
         objectiveVersionId?: string;
+        projectId?: string;
       }) => {
         if (!opts.intent && !opts.objectiveId) {
           printError("Either --intent or --objective-id is required.");
@@ -72,6 +75,9 @@ export function registerCreateCommand(evaluator: Command): void {
           }
           payload.models = r.value;
         }
+
+        const projectId = resolveProjectIdValue(opts.projectId);
+        if (projectId !== undefined) payload.projectId = projectId;
 
         const spinner = ora("Creating...").start();
         try {

--- a/cli/src/commands/evaluator/duplicate.ts
+++ b/cli/src/commands/evaluator/duplicate.ts
@@ -2,17 +2,23 @@ import { Command } from "commander";
 import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printJson, handleSdkError } from "../../output.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 
 export function registerDuplicateCommand(evaluator: Command): void {
   evaluator
     .command("duplicate <evaluatorId>")
     .description("Duplicate an existing evaluator")
-    .action(async (evaluatorId: string) => {
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
+    .action(async (evaluatorId: string, opts: { projectId?: string }) => {
       const apiKey = await requireApiKey();
       const spinner = ora("Duplicating...").start();
       try {
         const client = getSdkClient(apiKey);
-        const result = await client.evaluators.duplicate(evaluatorId);
+        const projectId = resolveProjectIdValue(opts.projectId);
+        const result = await client.evaluators.duplicate(
+          evaluatorId,
+          projectId !== undefined ? { projectId } : {},
+        );
         spinner.stop();
         printSuccess(`Evaluator ${evaluatorId} duplicated successfully!`);
         printJson(result);

--- a/cli/src/commands/evaluator/execute-by-name.ts
+++ b/cli/src/commands/evaluator/execute-by-name.ts
@@ -3,6 +3,7 @@ import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
 import { isTurnArray, isToolCatalog, isStringArray, isStringRecord } from "../../utils.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import type { ExecutionPayload } from "@root-signals/scorable";
 
 async function readStdinDefault(): Promise<string> {
@@ -25,6 +26,7 @@ export async function executeEvaluatorByName(
     sessionId?: string;
     systemPrompt?: string;
     variables?: string;
+    projectId?: string;
   },
   readStdin = readStdinDefault,
 ): Promise<void> {
@@ -105,6 +107,9 @@ export async function executeEvaluatorByName(
     }
   }
 
+  const projectId = resolveProjectIdValue(opts.projectId);
+  if (projectId !== undefined) payload.projectId = projectId;
+
   const spinner = ora("Running evaluator...").start();
   try {
     const client = getSdkClient(apiKey);
@@ -144,6 +149,7 @@ export function registerExecuteByNameCommand(evaluator: Command): void {
       "--variables <json>",
       'JSON object of extra template variables. E.g., \'{"lang":"EN"}\'',
     )
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
     .addHelpText(
       "after",
       `
@@ -192,6 +198,7 @@ Examples:
           sessionId?: string;
           systemPrompt?: string;
           variables?: string;
+          projectId?: string;
         },
       ) => {
         try {

--- a/cli/src/commands/evaluator/execute.ts
+++ b/cli/src/commands/evaluator/execute.ts
@@ -3,6 +3,7 @@ import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
 import { isTurnArray, isToolCatalog, isStringArray, isStringRecord } from "../../utils.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import type { ExecutionPayload } from "@root-signals/scorable";
 
 async function readStdinDefault(): Promise<string> {
@@ -26,6 +27,7 @@ export async function executeEvaluator(
     systemPrompt?: string;
     variables?: string;
     fileIds?: string;
+    projectId?: string;
   },
   readStdin = readStdinDefault,
 ): Promise<void> {
@@ -119,6 +121,9 @@ export async function executeEvaluator(
     payload.file_ids = parsed;
   }
 
+  const projectId = resolveProjectIdValue(opts.projectId);
+  if (projectId !== undefined) payload.projectId = projectId;
+
   const spinner = ora("Running evaluator...").start();
   try {
     const client = getSdkClient(apiKey);
@@ -162,6 +167,7 @@ export function registerExecuteCommand(evaluator: Command): void {
       "--file-ids <json>",
       "JSON array of file UUIDs from 'scorable file upload'. E.g., '[\"uuid1\"]'",
     )
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
     .addHelpText(
       "after",
       `
@@ -221,6 +227,7 @@ Examples:
           systemPrompt?: string;
           variables?: string;
           fileIds?: string;
+          projectId?: string;
         },
       ) => {
         try {

--- a/cli/src/commands/evaluator/export-yaml.ts
+++ b/cli/src/commands/evaluator/export-yaml.ts
@@ -4,6 +4,15 @@ import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, handleSdkError } from "../../output.js";
 
+// YAML exports are portable artifacts; embedding an org-local UUID would make them
+// footgun-y to re-import in another org. Strip it before emitting.
+function stripProjectId(yaml: string): string {
+  return yaml
+    .split("\n")
+    .filter((line) => !/^\s*project_id\s*:/.test(line))
+    .join("\n");
+}
+
 export function registerExportYamlCommand(evaluator: Command): void {
   evaluator
     .command("export-yaml")
@@ -15,7 +24,7 @@ export function registerExportYamlCommand(evaluator: Command): void {
       try {
         const apiKey = await requireApiKey();
         const client = getSdkClient(apiKey);
-        const yaml = await client.evaluators.exportYaml(id);
+        const yaml = stripProjectId(await client.evaluators.exportYaml(id));
         spinner.stop();
         if (opts.output) {
           writeFileSync(opts.output, yaml, "utf8");

--- a/cli/src/commands/evaluator/export-yaml.ts
+++ b/cli/src/commands/evaluator/export-yaml.ts
@@ -1,16 +1,19 @@
 import { writeFileSync } from "node:fs";
 import { Command } from "commander";
+import yaml from "js-yaml";
 import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, handleSdkError } from "../../output.js";
 
 // YAML exports are portable artifacts; embedding an org-local UUID would make them
 // footgun-y to re-import in another org. Strip it before emitting.
-function stripProjectId(yaml: string): string {
-  return yaml
-    .split("\n")
-    .filter((line) => !/^\s*project_id\s*:/.test(line))
-    .join("\n");
+function stripProjectId(yamlContent: string): string {
+  const parsed = yaml.load(yamlContent);
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    delete (parsed as Record<string, unknown>).project_id;
+    return yaml.dump(parsed);
+  }
+  return yamlContent;
 }
 
 export function registerExportYamlCommand(evaluator: Command): void {

--- a/cli/src/commands/evaluator/import-yaml.ts
+++ b/cli/src/commands/evaluator/import-yaml.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import ora from "ora";
 import { requireApiKey, getBaseUrl } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 
 export function registerImportYamlCommand(evaluator: Command): void {
   evaluator
@@ -10,7 +11,8 @@ export function registerImportYamlCommand(evaluator: Command): void {
     .description("Import an evaluator from a YAML file")
     .requiredOption("--file <path>", "Path to the YAML file to import")
     .option("--overwrite", "Overwrite if an evaluator with the same name already exists")
-    .action(async (opts: { file: string; overwrite?: boolean }) => {
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
+    .action(async (opts: { file: string; overwrite?: boolean; projectId?: string }) => {
       let yamlContent: string;
       try {
         yamlContent = readFileSync(opts.file, "utf8");
@@ -23,13 +25,19 @@ export function registerImportYamlCommand(evaluator: Command): void {
       try {
         const apiKey = await requireApiKey();
         const baseUrl = getBaseUrl();
+        const projectId = resolveProjectIdValue(opts.projectId);
+        const body: Record<string, unknown> = {
+          yaml: yamlContent,
+          overwrite: opts.overwrite ?? false,
+        };
+        if (projectId !== undefined) body["project_id"] = projectId;
         const response = await fetch(`${baseUrl}/v1/evaluators/import-yaml/`, {
           method: "POST",
           headers: {
             Authorization: `Api-Key ${apiKey}`,
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ yaml: yamlContent, overwrite: opts.overwrite ?? false }),
+          body: JSON.stringify(body),
         });
         if (!response.ok) {
           spinner.stop();

--- a/cli/src/commands/evaluator/list.ts
+++ b/cli/src/commands/evaluator/list.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printMessage, printEvaluatorTable, handleSdkError } from "../../output.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import type { EvaluatorListParams } from "@root-signals/scorable";
 
 export function registerListCommand(evaluator: Command): void {
@@ -13,6 +14,7 @@ export function registerListCommand(evaluator: Command): void {
     .option("--search <term>", "A search term to filter by")
     .option("--name <name>", "Filter by exact evaluator name")
     .option("--ordering <field>", "Which field to use for ordering the results")
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
     .action(
       async (opts: {
         pageSize?: number;
@@ -20,6 +22,7 @@ export function registerListCommand(evaluator: Command): void {
         search?: string;
         name?: string;
         ordering?: string;
+        projectId?: string;
       }) => {
         const apiKey = await requireApiKey();
 
@@ -29,6 +32,8 @@ export function registerListCommand(evaluator: Command): void {
         if (opts.search !== undefined) params.search = opts.search;
         if (opts.name !== undefined) params.name = opts.name;
         if (opts.ordering !== undefined) params.ordering = opts.ordering;
+        const projectId = resolveProjectIdValue(opts.projectId);
+        if (projectId !== undefined) params.projectId = projectId;
 
         const spinner = ora("Fetching...").start();
         try {

--- a/cli/src/commands/evaluator/update.ts
+++ b/cli/src/commands/evaluator/update.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printInfo, printSuccess, printError, printJson, handleSdkError } from "../../output.js";
 import { parseJsonArg } from "../../utils.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import type { EvaluatorUpdateParams } from "@root-signals/scorable";
 
 export function registerUpdateCommand(evaluator: Command): void {
@@ -15,6 +16,10 @@ export function registerUpdateCommand(evaluator: Command): void {
     .option("--models <json>", "JSON array of model names. E.g., '[\"gpt-5.5\"]'")
     .option("--objective-id <id>", "The new objective ID")
     .option("--objective-version-id <id>", "The new objective version ID")
+    .option(
+      "--project-id <uuid>",
+      "Move the evaluator to this project (within the same organization). " + PROJECT_ID_FLAG_DESC,
+    )
     .action(
       async (
         evaluatorId: string,
@@ -24,6 +29,7 @@ export function registerUpdateCommand(evaluator: Command): void {
           models?: string;
           objectiveId?: string;
           objectiveVersionId?: string;
+          projectId?: string;
         },
       ) => {
         const apiKey = await requireApiKey();
@@ -45,6 +51,9 @@ export function registerUpdateCommand(evaluator: Command): void {
           }
           payload.models = r.value;
         }
+
+        const projectId = resolveProjectIdValue(opts.projectId);
+        if (projectId !== undefined) payload.projectId = projectId;
 
         if (Object.keys(payload).length === 0) {
           printInfo("No update parameters provided. Aborting.");

--- a/cli/src/commands/execution-log/list.ts
+++ b/cli/src/commands/execution-log/list.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printMessage, printExecutionLogTable, handleSdkError } from "../../output.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import type { ExecutionLogListParams } from "@root-signals/scorable";
 
 export function registerListCommand(executionLog: Command): void {
@@ -20,6 +21,7 @@ export function registerListCommand(executionLog: Command): void {
     .option("--created-at-after <date>", "Filter logs created after this date (ISO 8601)")
     .option("--created-at-before <date>", "Filter logs created before this date (ISO 8601)")
     .option("--owner-email <email>", "Filter by owner email")
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
     .action(
       async (opts: {
         pageSize?: number;
@@ -34,6 +36,7 @@ export function registerListCommand(executionLog: Command): void {
         createdAtAfter?: string;
         createdAtBefore?: string;
         ownerEmail?: string;
+        projectId?: string;
       }) => {
         const apiKey = await requireApiKey();
 
@@ -50,6 +53,8 @@ export function registerListCommand(executionLog: Command): void {
         if (opts.createdAtAfter !== undefined) params.created_at_after = opts.createdAtAfter;
         if (opts.createdAtBefore !== undefined) params.created_at_before = opts.createdAtBefore;
         if (opts.ownerEmail !== undefined) params.owner__email = opts.ownerEmail;
+        const projectId = resolveProjectIdValue(opts.projectId);
+        if (projectId !== undefined) params.projectId = projectId;
 
         const spinner = ora("Fetching...").start();
         try {

--- a/cli/src/commands/judge/create.ts
+++ b/cli/src/commands/judge/create.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
 import { parseJsonArg } from "../../utils.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import type { CreateJudgeData } from "@root-signals/scorable";
 
 const EvaluatorRefsSchema = z.array(z.object({ id: z.string() }).passthrough());
@@ -19,12 +20,14 @@ export function registerCreateCommand(judge: Command): void {
       "--evaluator-references <json>",
       'JSON string for evaluator references. E.g., \'[{"id": "eval-id"}]\'',
     )
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
     .action(
       async (opts: {
         name: string;
         intent: string;
         stage?: string;
         evaluatorReferences?: string;
+        projectId?: string;
       }) => {
         const apiKey = await requireApiKey();
 
@@ -41,6 +44,9 @@ export function registerCreateCommand(judge: Command): void {
           }
           payload.evaluator_references = r.value;
         }
+
+        const projectId = resolveProjectIdValue(opts.projectId);
+        if (projectId !== undefined) payload.projectId = projectId;
 
         const spinner = ora("Creating...").start();
         try {

--- a/cli/src/commands/judge/duplicate.ts
+++ b/cli/src/commands/judge/duplicate.ts
@@ -2,17 +2,23 @@ import { Command } from "commander";
 import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printJson, handleSdkError } from "../../output.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 
 export function registerDuplicateCommand(judge: Command): void {
   judge
     .command("duplicate <judgeId>")
     .description("Duplicate an existing judge")
-    .action(async (judgeId: string) => {
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
+    .action(async (judgeId: string, opts: { projectId?: string }) => {
       const apiKey = await requireApiKey();
       const spinner = ora("Duplicating...").start();
       try {
         const client = getSdkClient(apiKey);
-        const result = await client.judges.duplicate(judgeId);
+        const projectId = resolveProjectIdValue(opts.projectId);
+        const result = await client.judges.duplicate(
+          judgeId,
+          projectId !== undefined ? { projectId } : {},
+        );
         spinner.stop();
         printSuccess(`Judge ${judgeId} duplicated successfully!`);
         printJson(result);

--- a/cli/src/commands/judge/exec-openai-generic.ts
+++ b/cli/src/commands/judge/exec-openai-generic.ts
@@ -10,6 +10,7 @@ import {
   handleSdkError,
 } from "../../output.js";
 import { parseJsonArg } from "../../utils.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import { apiRequest } from "../../client.js";
 
 const MessagesSchema = z.array(z.object({ role: z.string() }).passthrough());
@@ -22,46 +23,53 @@ export function registerExecOpenaiGenericCommand(judge: Command): void {
     .requiredOption("--model <model>", "Judge ID (or name) to use as the 'model' field")
     .requiredOption("--messages <json>", "JSON string of the messages payload")
     .option("--extra-body <json>", "Optional JSON string for extra_body parameters")
-    .action(async (opts: { model: string; messages: string; extraBody?: string }) => {
-      const apiKey = await requireApiKey();
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
+    .action(
+      async (opts: { model: string; messages: string; extraBody?: string; projectId?: string }) => {
+        const apiKey = await requireApiKey();
 
-      const messagesResult = parseJsonArg(opts.messages, MessagesSchema);
-      if (!messagesResult.ok) {
-        printError(
-          "Invalid JSON for --messages. Expected an array of objects each with a string `role`. Aborting.",
-        );
-        return;
-      }
-
-      const payload: Record<string, unknown> = {
-        model: opts.model,
-        messages: messagesResult.value,
-      };
-
-      if (opts.extraBody) {
-        const extraResult = parseJsonArg(opts.extraBody, ExtraBodySchema);
-        if (extraResult.ok) {
-          payload["extra_body"] = extraResult.value;
-        } else {
-          printWarning("Invalid JSON for --extra-body (expected an object). Skipping.");
+        const messagesResult = parseJsonArg(opts.messages, MessagesSchema);
+        if (!messagesResult.ok) {
+          printError(
+            "Invalid JSON for --messages. Expected an array of objects each with a string `role`. Aborting.",
+          );
+          return;
         }
-      }
 
-      printInfo(`Executing a Judge using generic OpenAI endpoint. Judge ID/Name: ${opts.model}`);
-      printInfo("Attempting to execute with OpenAI compatible payload:");
-      printJson(payload);
+        const payload: Record<string, unknown> = {
+          model: opts.model,
+          messages: messagesResult.value,
+        };
 
-      try {
-        const result = await apiRequest("POST", "judges/openai/chat/completions", {
-          payload,
-          apiKey,
-        });
-        if (result) {
-          printSuccess("OpenAI compatible execution successful!");
-          printJson(result);
+        if (opts.extraBody) {
+          const extraResult = parseJsonArg(opts.extraBody, ExtraBodySchema);
+          if (extraResult.ok) {
+            payload["extra_body"] = extraResult.value;
+          } else {
+            printWarning("Invalid JSON for --extra-body (expected an object). Skipping.");
+          }
         }
-      } catch (e) {
-        handleSdkError(e);
-      }
-    });
+
+        printInfo(`Executing a Judge using generic OpenAI endpoint. Judge ID/Name: ${opts.model}`);
+        printInfo("Attempting to execute with OpenAI compatible payload:");
+        printJson(payload);
+
+        const projectId = resolveProjectIdValue(opts.projectId);
+        const headers = projectId !== undefined ? { "X-Project-Id": projectId } : undefined;
+
+        try {
+          const result = await apiRequest("POST", "judges/openai/chat/completions", {
+            payload,
+            apiKey,
+            headers,
+          });
+          if (result) {
+            printSuccess("OpenAI compatible execution successful!");
+            printJson(result);
+          }
+        } catch (e) {
+          handleSdkError(e);
+        }
+      },
+    );
 }

--- a/cli/src/commands/judge/exec-openai.ts
+++ b/cli/src/commands/judge/exec-openai.ts
@@ -10,6 +10,7 @@ import {
   handleSdkError,
 } from "../../output.js";
 import { parseJsonArg } from "../../utils.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import { apiRequest } from "../../client.js";
 
 const MessagesSchema = z.array(z.object({ role: z.string() }).passthrough());
@@ -22,10 +23,11 @@ export function registerExecOpenaiCommand(judge: Command): void {
     .requiredOption("--model <model>", "LLM model for judge execution (e.g., gpt-5.5)")
     .requiredOption("--messages <json>", "JSON string of the messages payload")
     .option("--extra-body <json>", "Optional JSON string for extra_body parameters")
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
     .action(
       async (
         judgeIdInPath: string,
-        opts: { model: string; messages: string; extraBody?: string },
+        opts: { model: string; messages: string; extraBody?: string; projectId?: string },
       ) => {
         const apiKey = await requireApiKey();
 
@@ -57,6 +59,9 @@ export function registerExecOpenaiCommand(judge: Command): void {
         printInfo("Attempting to execute with OpenAI compatible payload:");
         printJson(payload);
 
+        const projectId = resolveProjectIdValue(opts.projectId);
+        const headers = projectId !== undefined ? { "X-Project-Id": projectId } : undefined;
+
         try {
           const result = await apiRequest(
             "POST",
@@ -64,6 +69,7 @@ export function registerExecOpenaiCommand(judge: Command): void {
             {
               payload,
               apiKey,
+              headers,
             },
           );
           if (result) {

--- a/cli/src/commands/judge/execute-by-name.ts
+++ b/cli/src/commands/judge/execute-by-name.ts
@@ -3,6 +3,7 @@ import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
 import { isTurnArray, isToolCatalog, isStringArray } from "../../utils.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import type { JudgeExecutionPayload } from "@root-signals/scorable";
 
 async function readStdinDefault(): Promise<string> {
@@ -24,6 +25,7 @@ export async function executeJudgeByName(
     userId?: string;
     sessionId?: string;
     systemPrompt?: string;
+    projectId?: string;
   },
   readStdin = readStdinDefault,
 ): Promise<void> {
@@ -90,6 +92,9 @@ export async function executeJudgeByName(
     }
   }
 
+  const projectId = resolveProjectIdValue(opts.projectId);
+  if (projectId !== undefined) payload.projectId = projectId;
+
   const spinner = ora("Running judge...").start();
   try {
     const client = getSdkClient(apiKey);
@@ -125,6 +130,7 @@ export function registerExecuteByNameCommand(judge: Command): void {
       'JSON array of conversation turns. Roles: user|assistant|tool. Assistant turns may carry `tool_calls`; tool results use a `tool` role with `tool_call_id`. E.g., \'[{"role":"user","content":"Hello"}]\'',
     )
     .option("--tools <json>", "JSON array of OpenAI-style tool definitions available to the agent.")
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
     .addHelpText(
       "after",
       `
@@ -167,6 +173,7 @@ Examples:
           userId?: string;
           sessionId?: string;
           systemPrompt?: string;
+          projectId?: string;
         },
       ) => {
         try {

--- a/cli/src/commands/judge/execute.ts
+++ b/cli/src/commands/judge/execute.ts
@@ -3,6 +3,7 @@ import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
 import { isTurnArray, isToolCatalog, isStringArray } from "../../utils.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import type { JudgeExecutionPayload } from "@root-signals/scorable";
 
 async function readStdinDefault(): Promise<string> {
@@ -24,6 +25,7 @@ export async function executeJudge(
     userId?: string;
     sessionId?: string;
     systemPrompt?: string;
+    projectId?: string;
   },
   readStdin = readStdinDefault,
 ): Promise<void> {
@@ -90,6 +92,9 @@ export async function executeJudge(
     }
   }
 
+  const projectId = resolveProjectIdValue(opts.projectId);
+  if (projectId !== undefined) payload.projectId = projectId;
+
   const spinner = ora("Running judge...").start();
   try {
     const client = getSdkClient(apiKey);
@@ -125,6 +130,7 @@ export function registerExecuteCommand(judge: Command): void {
       'JSON array of conversation turns. Roles: user|assistant|tool. Assistant turns may carry `tool_calls`; tool results use a `tool` role with `tool_call_id`. E.g., \'[{"role":"user","content":"Hello"}]\'',
     )
     .option("--tools <json>", "JSON array of OpenAI-style tool definitions available to the agent.")
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
     .addHelpText(
       "after",
       `
@@ -174,6 +180,7 @@ Examples:
           userId?: string;
           sessionId?: string;
           systemPrompt?: string;
+          projectId?: string;
         },
       ) => {
         try {

--- a/cli/src/commands/judge/generate.ts
+++ b/cli/src/commands/judge/generate.ts
@@ -12,6 +12,7 @@ import {
   handleSdkError,
 } from "../../output.js";
 import { parseJsonArg } from "../../utils.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import { CliError } from "../../types.js";
 import { uploadFile } from "../file/upload.js";
 
@@ -50,6 +51,7 @@ offer to connect the guest with a human agent when uncertain."`,
       "Path to a file (PDF, PNG, JPG) to upload and attach as context for the judge",
     )
     .option("--file-id <id>", "ID of an already-uploaded file to use as context for the judge")
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
     .action(
       async (opts: {
         intent: string;
@@ -63,6 +65,7 @@ offer to connect the guest with a human agent when uncertain."`,
         contextAware: boolean;
         file?: string;
         fileId?: string;
+        projectId?: string;
       }) => {
         const acceptedVisibilities = ["private", "public"] as const;
         const visibility = opts.visibility;
@@ -99,6 +102,7 @@ offer to connect the guest with a human agent when uncertain."`,
           }
 
           const client = getSdkClient(apiKey);
+          const projectId = resolveProjectIdValue(opts.projectId);
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const result = (await client.judges.generate({
             intent: opts.intent,
@@ -110,6 +114,7 @@ offer to connect the guest with a human agent when uncertain."`,
             file_id: fileId,
             extra_contexts: extra_contexts ?? null,
             enable_context_aware_evaluators: opts.contextAware || undefined,
+            ...(projectId !== undefined ? { projectId } : {}),
             ...(opts.reasoningEffort && {
               generating_model_params: {
                 reasoning_effort: opts.reasoningEffort as "off" | "low" | "medium" | "high",

--- a/cli/src/commands/judge/update.ts
+++ b/cli/src/commands/judge/update.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { requireApiKey, getSdkClient } from "../../auth.js";
 import { printInfo, printSuccess, printError, printJson, handleSdkError } from "../../output.js";
 import { parseJsonArg } from "../../utils.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import type { UpdateJudgeData } from "@root-signals/scorable";
 
 const EvaluatorRefsSchema = z.array(z.object({ id: z.string() }).passthrough());
@@ -18,10 +19,19 @@ export function registerUpdateCommand(judge: Command): void {
       "--evaluator-references <json>",
       'JSON string to update evaluator references. Use "[]" to clear.',
     )
+    .option(
+      "--project-id <uuid>",
+      "Move the judge to this project (within the same organization). " + PROJECT_ID_FLAG_DESC,
+    )
     .action(
       async (
         judgeId: string,
-        opts: { name?: string; stage?: string; evaluatorReferences?: string },
+        opts: {
+          name?: string;
+          stage?: string;
+          evaluatorReferences?: string;
+          projectId?: string;
+        },
       ) => {
         const apiKey = await requireApiKey();
 
@@ -39,6 +49,9 @@ export function registerUpdateCommand(judge: Command): void {
           }
           payload.evaluator_references = r.value;
         }
+
+        const projectId = resolveProjectIdValue(opts.projectId);
+        if (projectId !== undefined) payload.projectId = projectId;
 
         if (Object.keys(payload).length === 0) {
           printInfo("No update parameters provided. Aborting.");

--- a/cli/src/commands/project/create.ts
+++ b/cli/src/commands/project/create.ts
@@ -1,0 +1,37 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, printJson, handleSdkError } from "../../output.js";
+import type { CreateProjectParams } from "@root-signals/scorable";
+
+export function registerCreateCommand(project: Command): void {
+  project
+    .command("create")
+    .description("Create a new project")
+    .requiredOption("--name <name>", "Project name")
+    .option("--description <text>", "Project description")
+    .option(
+      "--is-default",
+      "Mark this project as the org default (atomically clears any previous default).",
+      false,
+    )
+    .action(async (opts: { name: string; description?: string; isDefault?: boolean }) => {
+      const apiKey = await requireApiKey();
+
+      const payload: CreateProjectParams = { name: opts.name };
+      if (opts.description !== undefined) payload.description = opts.description;
+      if (opts.isDefault) payload.is_default = true;
+
+      const spinner = ora("Creating...").start();
+      try {
+        const client = getSdkClient(apiKey);
+        const result = await client.projects.create(payload);
+        spinner.stop();
+        printSuccess("Project created successfully!");
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/project/delete.ts
+++ b/cli/src/commands/project/delete.ts
@@ -1,0 +1,43 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, handleSdkError } from "../../output.js";
+import { CliError } from "../../types.js";
+
+export function registerDeleteCommand(project: Command): void {
+  project
+    .command("delete <projectId>")
+    .description("Delete a project by its ID")
+    .option("--yes", "Skip confirmation prompt")
+    .action(async (projectId: string, opts: { yes?: boolean }) => {
+      const apiKey = await requireApiKey();
+
+      if (!opts.yes) {
+        if (!process.stdin.isTTY || !process.stdout.isTTY) {
+          throw new CliError(
+            1,
+            "Refusing to prompt for confirmation in a non-interactive environment. Pass --yes to skip the prompt.",
+          );
+        }
+        const { confirm } = await import("@inquirer/prompts");
+        const ok = await confirm({
+          message: "Are you sure you want to delete this project?",
+          default: false,
+        });
+        if (!ok) {
+          throw new CliError(1, "Aborted");
+        }
+      }
+
+      const spinner = ora("Deleting...").start();
+      try {
+        const client = getSdkClient(apiKey);
+        await client.projects.delete(projectId);
+        spinner.stop();
+        printSuccess(`Project ${projectId} deleted successfully.`);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/project/get.ts
+++ b/cli/src/commands/project/get.ts
@@ -1,0 +1,24 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, printJson, handleSdkError } from "../../output.js";
+
+export function registerGetCommand(project: Command): void {
+  project
+    .command("get <projectId>")
+    .description("Get a specific project by its ID")
+    .action(async (projectId: string) => {
+      const apiKey = await requireApiKey();
+      const spinner = ora("Fetching...").start();
+      try {
+        const client = getSdkClient(apiKey);
+        const result = await client.projects.retrieve(projectId);
+        spinner.stop();
+        printSuccess(`Project '${result.name}' details:`);
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/project/index.ts
+++ b/cli/src/commands/project/index.ts
@@ -1,0 +1,20 @@
+import { Command } from "commander";
+import { registerListCommand } from "./list.js";
+import { registerGetCommand } from "./get.js";
+import { registerCreateCommand } from "./create.js";
+import { registerUpdateCommand } from "./update.js";
+import { registerDeleteCommand } from "./delete.js";
+import { registerSetDefaultCommand } from "./set-default.js";
+
+export function registerProjectCommands(program: Command): void {
+  const project = new Command("project").description("Project management commands");
+
+  registerListCommand(project);
+  registerGetCommand(project);
+  registerCreateCommand(project);
+  registerUpdateCommand(project);
+  registerDeleteCommand(project);
+  registerSetDefaultCommand(project);
+
+  program.addCommand(project);
+}

--- a/cli/src/commands/project/list.ts
+++ b/cli/src/commands/project/list.ts
@@ -1,52 +1,39 @@
 import { Command } from "commander";
 import ora from "ora";
 import { requireApiKey, getSdkClient } from "../../auth.js";
-import { printMessage, printJudgeTable, handleSdkError } from "../../output.js";
-import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
-import type { JudgeListParams } from "@root-signals/scorable";
+import { printMessage, printProjectTable, handleSdkError } from "../../output.js";
+import type { ProjectListParams } from "@root-signals/scorable";
 
-export function registerListCommand(judge: Command): void {
-  judge
+export function registerListCommand(project: Command): void {
+  project
     .command("list")
-    .description("List judges with optional filters")
+    .description("List projects in your organization")
     .option("--page-size <number>", "Number of results to return per page", parseInt)
     .option("--cursor <cursor>", "The pagination cursor value")
     .option("--search <term>", "A search term to filter by")
-    .option("--name <name>", "Filter by exact judge name")
     .option("--ordering <field>", "Which field to use for ordering the results")
-    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
     .action(
-      async (opts: {
-        pageSize?: number;
-        cursor?: string;
-        search?: string;
-        name?: string;
-        ordering?: string;
-        projectId?: string;
-      }) => {
+      async (opts: { pageSize?: number; cursor?: string; search?: string; ordering?: string }) => {
         const apiKey = await requireApiKey();
 
-        const params: JudgeListParams & { name?: string } = {};
+        const params: ProjectListParams = {};
         if (opts.pageSize !== undefined) params.page_size = opts.pageSize;
         if (opts.cursor !== undefined) params.cursor = opts.cursor;
         if (opts.search !== undefined) params.search = opts.search;
-        if (opts.name !== undefined) params.name = opts.name;
         if (opts.ordering !== undefined) params.ordering = opts.ordering;
-        const projectId = resolveProjectIdValue(opts.projectId);
-        if (projectId !== undefined) params.projectId = projectId;
 
         const spinner = ora("Fetching...").start();
         try {
           const client = getSdkClient(apiKey);
-          const response = await client.judges.list(params);
+          const response = await client.projects.list(params);
           spinner.stop();
 
           if (!response.results.length) {
-            printMessage("No judges found.");
+            printMessage("No projects found.");
             return;
           }
 
-          printJudgeTable(response.results, response.next);
+          printProjectTable(response.results, response.next);
         } catch (e) {
           spinner.stop();
           handleSdkError(e);

--- a/cli/src/commands/project/list.ts
+++ b/cli/src/commands/project/list.ts
@@ -8,7 +8,7 @@ export function registerListCommand(project: Command): void {
   project
     .command("list")
     .description("List projects in your organization")
-    .option("--page-size <number>", "Number of results to return per page", parseInt)
+    .option("--page-size <number>", "Number of results to return per page", (v) => parseInt(v, 10))
     .option("--cursor <cursor>", "The pagination cursor value")
     .option("--search <term>", "A search term to filter by")
     .option("--ordering <field>", "Which field to use for ordering the results")

--- a/cli/src/commands/project/set-default.ts
+++ b/cli/src/commands/project/set-default.ts
@@ -1,0 +1,24 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, printJson, handleSdkError } from "../../output.js";
+
+export function registerSetDefaultCommand(project: Command): void {
+  project
+    .command("set-default <projectId>")
+    .description("Promote a project to the org default. Atomically clears the previous default.")
+    .action(async (projectId: string) => {
+      const apiKey = await requireApiKey();
+      const spinner = ora("Updating default project...").start();
+      try {
+        const client = getSdkClient(apiKey);
+        const result = await client.projects.update(projectId, { is_default: true });
+        spinner.stop();
+        printSuccess(`Project ${projectId} is now the org default.`);
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/project/update.ts
+++ b/cli/src/commands/project/update.ts
@@ -1,0 +1,48 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, printInfo, printJson, handleSdkError } from "../../output.js";
+import type { UpdateProjectParams } from "@root-signals/scorable";
+
+export function registerUpdateCommand(project: Command): void {
+  project
+    .command("update <projectId>")
+    .description("Update an existing project (PATCH)")
+    .option("--name <name>", "New project name")
+    .option("--description <text>", "New project description")
+    .option(
+      "--is-default",
+      "Promote this project to org default. Atomically clears the previous default. Clearing the default directly is not supported by the backend; promote another project instead.",
+      false,
+    )
+    .action(
+      async (
+        projectId: string,
+        opts: { name?: string; description?: string; isDefault?: boolean },
+      ) => {
+        const apiKey = await requireApiKey();
+
+        const payload: UpdateProjectParams = {};
+        if (opts.name !== undefined) payload.name = opts.name;
+        if (opts.description !== undefined) payload.description = opts.description;
+        if (opts.isDefault) payload.is_default = true;
+
+        if (Object.keys(payload).length === 0) {
+          printInfo("No update parameters provided. Aborting.");
+          return;
+        }
+
+        const spinner = ora("Updating...").start();
+        try {
+          const client = getSdkClient(apiKey);
+          const result = await client.projects.update(projectId, payload);
+          spinner.stop();
+          printSuccess(`Project ${projectId} updated successfully!`);
+          printJson(result);
+        } catch (e) {
+          spinner.stop();
+          handleSdkError(e);
+        }
+      },
+    );
+}

--- a/cli/src/commands/prompt-test/init.ts
+++ b/cli/src/commands/prompt-test/init.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { writeFileSync, existsSync } from "node:fs";
 import { printWarning, printSuccess, printInfo, printError } from "../../output.js";
+import { PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 
 const TEMPLATE = `# Prompt Testing Configuration
 # This file defines a test suite of prompt and model combinations, with optional evaluators.
@@ -51,10 +52,17 @@ evaluators:
 #   additionalProperties: false
 `;
 
+function buildTemplate(projectId?: string): string {
+  if (!projectId) return TEMPLATE;
+  // Append the project_id field to the template so it ends up in the generated config.
+  return `${TEMPLATE}\n# Project to assign prompt-test runs to. Override per-run with \`--project-id\`.\nproject_id: "${projectId}"\n`;
+}
+
 export function registerInitCommand(pt: Command): void {
   pt.command("init")
     .description("Initializes a new prompt-tests.yaml file in the current directory")
-    .action(async () => {
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
+    .action(async (opts: { projectId?: string }) => {
       const configPath = "prompt-tests.yaml";
 
       if (existsSync(configPath)) {
@@ -71,7 +79,7 @@ export function registerInitCommand(pt: Command): void {
       }
 
       try {
-        writeFileSync(configPath, TEMPLATE);
+        writeFileSync(configPath, buildTemplate(opts.projectId));
         printSuccess(`'${configPath}' created successfully.`);
         printInfo("Update the file with your prompt test details and run `pt run`.");
       } catch (e) {

--- a/cli/src/commands/prompt-test/run.ts
+++ b/cli/src/commands/prompt-test/run.ts
@@ -25,6 +25,7 @@ const UNICODE_CHARS = {
   middle: "│",
 };
 import { CliError } from "../../types.js";
+import { resolveProjectIdValue, PROJECT_ID_FLAG_DESC } from "../../lib/project-id.js";
 import type { PromptTest, PromptTestConfig } from "../../types.js";
 
 function isPromptTestComplete(exp: PromptTest): boolean {
@@ -111,6 +112,7 @@ export async function runPromptTests(
   outputFile: string | undefined,
   configPath: string,
   sleep: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms)),
+  projectIdOverride?: string,
 ): Promise<void> {
   let rawConfig: unknown;
   try {
@@ -141,6 +143,15 @@ export async function runPromptTests(
   const apiKey = await requireApiKey();
   printInfo("Starting prompt tests");
 
+  // Resolution: --project-id override > config file > env > settings.
+  // Passing `--project-id` to `run` invokes resolveProjectIdValue, which already
+  // covers the env/settings fallback. The config file lives below the flag and
+  // above env, so we honour it explicitly here.
+  const resolvedProjectId =
+    projectIdOverride !== undefined
+      ? resolveProjectIdValue(projectIdOverride)
+      : (config.project_id ?? resolveProjectIdValue(undefined));
+
   const experiments: Record<string, PromptTest> = {};
 
   for (const prompt of config.prompts) {
@@ -161,6 +172,7 @@ export async function runPromptTests(
       };
       if (config.response_schema) payload["response_schema"] = config.response_schema;
       if (config.dataset_id) payload["dataset_id"] = config.dataset_id;
+      if (resolvedProjectId !== undefined) payload["project_id"] = resolvedProjectId;
 
       const result = (await apiRequest("POST", "prompt-tests", {
         payload,
@@ -231,9 +243,10 @@ export function registerRunCommand(pt: Command): void {
     .description("Runs prompt tests from the prompt-tests.yaml file")
     .option("-o, --output <path>", "Output file path to save prompt test results as JSON")
     .option("-c, --config <path>", "Path to prompt testing configuration file", "prompt-tests.yaml")
-    .action(async (opts: { output?: string; config: string }) => {
+    .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC + " Overrides project_id from config file.")
+    .action(async (opts: { output?: string; config: string; projectId?: string }) => {
       try {
-        await runPromptTests(opts.output, opts.config);
+        await runPromptTests(opts.output, opts.config, undefined, opts.projectId);
       } catch (e) {
         handleSdkError(e);
       }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -14,6 +14,7 @@ import { registerFileCommands } from "./commands/file/index.js";
 import { registerOtelFilterCommands } from "./commands/otel-filter/index.js";
 import { registerOtelTraceCommands } from "./commands/otel-trace/index.js";
 import { registerModelCommands } from "./commands/model/index.js";
+import { registerProjectCommands } from "./commands/project/index.js";
 
 const { version } = createRequire(import.meta.url)("../package.json") as {
   version: string;
@@ -83,6 +84,7 @@ export function createCli(): Command {
   registerOtelFilterCommands(program);
   registerOtelTraceCommands(program);
   registerModelCommands(program);
+  registerProjectCommands(program);
 
   return program;
 }

--- a/cli/src/lib/project-id.ts
+++ b/cli/src/lib/project-id.ts
@@ -1,0 +1,58 @@
+import { loadSettings } from "../auth.js";
+
+export type ProjectIdSource = "flag" | "env" | "settings" | "none";
+
+export interface ResolvedProjectId {
+  /**
+   * The resolved project id to send to the backend, or undefined to omit
+   * (lets the backend apply its default resolution).
+   */
+  value: string | undefined;
+  source: ProjectIdSource;
+}
+
+/**
+ * Resolution order:
+ *   1. --project-id <uuid>          (CLI flag, non-empty)
+ *   2. --project-id ""              (explicit empty — opt out, do NOT send)
+ *   3. SCORABLE_PROJECT_ID env var
+ *   4. project_id in ~/.scorable/settings.json
+ *   5. omitted — backend applies its standard resolution
+ *
+ * No local UUID validation; the backend rejects malformed ids with a 400.
+ */
+export function resolveProjectId(flagValue?: string): ResolvedProjectId {
+  if (flagValue !== undefined) {
+    if (flagValue === "") {
+      // Explicit opt-out — do not inherit from env or settings.
+      return { value: undefined, source: "flag" };
+    }
+    return { value: flagValue, source: "flag" };
+  }
+
+  const fromEnv = process.env["SCORABLE_PROJECT_ID"];
+  if (fromEnv !== undefined && fromEnv !== "") {
+    return { value: fromEnv, source: "env" };
+  }
+
+  const settings = loadSettings();
+  const fromSettings = settings["project_id"];
+  if (typeof fromSettings === "string" && fromSettings !== "") {
+    return { value: fromSettings, source: "settings" };
+  }
+
+  return { value: undefined, source: "none" };
+}
+
+/**
+ * Convenience: return only the value to send (undefined means "omit").
+ */
+export function resolveProjectIdValue(flagValue?: string): string | undefined {
+  return resolveProjectId(flagValue).value;
+}
+
+/**
+ * Common help text for the --project-id flag, shared across commands.
+ */
+export const PROJECT_ID_FLAG_DESC =
+  'Project UUID to scope this operation. Pass "" to opt out of inherited defaults from SCORABLE_PROJECT_ID or ~/.scorable/settings.json.';

--- a/cli/src/output.ts
+++ b/cli/src/output.ts
@@ -1,7 +1,14 @@
 import chalk from "chalk";
 import Table from "cli-table3";
+import { ScorableError } from "@root-signals/scorable";
 import { CliError } from "./types.js";
-import type { Judge, EvaluatorListItem, ExecutionLogList, ModelList } from "@root-signals/scorable";
+import type {
+  Judge,
+  EvaluatorListItem,
+  ExecutionLogList,
+  ModelList,
+  Project,
+} from "@root-signals/scorable";
 
 const UNICODE_CHARS = {
   top: "─",
@@ -29,11 +36,39 @@ export function printError(msg: string): void {
   console.error(chalk.red("✖") + " " + msg);
 }
 
+function extractBackendMessage(details: unknown): string | undefined {
+  // DRF error bodies come in a handful of shapes — prefer the most specific one.
+  if (!details || typeof details !== "object") return undefined;
+  const d = details as Record<string, unknown>;
+  if (typeof d["detail"] === "string") return d["detail"];
+  if (typeof d["title"] === "string") return d["title"];
+  if (typeof d["error"] === "string") return d["error"];
+  if (typeof d["message"] === "string") return d["message"];
+  // DRF non_field_errors / field-level lists — join the first one we find.
+  for (const v of Object.values(d)) {
+    if (Array.isArray(v) && v.length && typeof v[0] === "string") {
+      return v[0] as string;
+    }
+  }
+  return undefined;
+}
+
 export function handleSdkError(e: unknown): never {
   if (e instanceof CliError) throw e;
-  const message = e instanceof Error ? e.message || String(e) : String(e);
-  printError(message);
-  throw new CliError(1, message);
+  let message: string;
+  if (e instanceof ScorableError) {
+    // Surface the raw backend body when available so 400/422/409 messages flow through verbatim.
+    const detail = extractBackendMessage(e.details);
+    message = detail ?? e.detail ?? e.title ?? e.message ?? `API Error ${e.status}: ${e.code}`;
+  } else if (e instanceof Error) {
+    message = e.message || String(e);
+  } else {
+    message = String(e);
+  }
+  // Force single-line output for scriptability.
+  const oneLine = message.replace(/\s*\n\s*/g, " ").trim();
+  printError(oneLine);
+  throw new CliError(1, oneLine);
 }
 
 export function printSuccess(msg: string): void {
@@ -56,17 +91,21 @@ function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max - 1) + "…" : s;
 }
 
+function projectIdCell(value: string | null | undefined): string {
+  return value ?? "";
+}
+
 export function printJudgeTable(judges: Judge[], nextCursor?: string): void {
   const table = new Table({
-    head: ["ID", "Name", "Intent", "Created At"].map((h) => chalk.bold.cyan(h)),
+    head: ["ID", "Name", "Intent", "Project ID", "Created At"].map((h) => chalk.bold.cyan(h)),
     chars: UNICODE_CHARS,
-    colWidths: [38, 30, 52, 12],
+    colWidths: [38, 24, 40, 38, 12],
     wordWrap: true,
   });
 
   for (const j of judges) {
     const date = (j.created_at ?? "").slice(0, 10);
-    table.push([j.id, j.name, truncate(j.intent ?? "", 50), date]);
+    table.push([j.id, j.name, truncate(j.intent ?? "", 38), projectIdCell(j.project_id), date]);
   }
 
   console.log(table.toString());
@@ -79,15 +118,37 @@ export function printJudgeTable(judges: Judge[], nextCursor?: string): void {
 
 export function printEvaluatorTable(evaluators: EvaluatorListItem[], nextCursor?: string): void {
   const table = new Table({
-    head: ["ID", "Name", "Created At"].map((h) => chalk.bold.cyan(h)),
+    head: ["ID", "Name", "Project ID", "Created At"].map((h) => chalk.bold.cyan(h)),
     chars: UNICODE_CHARS,
-    colWidths: [38, 30, 12],
+    colWidths: [38, 30, 38, 12],
     wordWrap: true,
   });
 
   for (const e of evaluators) {
     const date = (e.created_at ?? "").slice(0, 10);
-    table.push([e.id, e.name, date]);
+    table.push([e.id, e.name, projectIdCell(e.project_id), date]);
+  }
+
+  console.log(table.toString());
+
+  if (nextCursor) {
+    const cursor = nextCursor.split("cursor=")[1] ?? nextCursor;
+    printInfo(`Next page available. Use --cursor "${cursor}"`);
+  }
+}
+
+export function printProjectTable(projects: Project[], nextCursor?: string): void {
+  const table = new Table({
+    head: ["ID", "Name", "Description", "Created At"].map((h) => chalk.bold.cyan(h)),
+    chars: UNICODE_CHARS,
+    colWidths: [38, 30, 40, 12],
+    wordWrap: true,
+  });
+
+  for (const p of projects) {
+    const date = (p.created_at ?? "").slice(0, 10);
+    const name = p.is_default ? `${p.name} (default)` : p.name;
+    table.push([p.id, name, truncate(p.description ?? "", 38), date]);
   }
 
   console.log(table.toString());
@@ -121,16 +182,25 @@ export function printModelTable(models: ModelList[], nextCursor?: string): void 
 
 export function printExecutionLogTable(logs: ExecutionLogList[], nextCursor?: string): void {
   const table = new Table({
-    head: ["ID", "Item Name", "Type", "Score", "Created At"].map((h) => chalk.bold.cyan(h)),
+    head: ["ID", "Item Name", "Type", "Score", "Project ID", "Created At"].map((h) =>
+      chalk.bold.cyan(h),
+    ),
     chars: UNICODE_CHARS,
-    colWidths: [38, 30, 15, 8, 12],
+    colWidths: [38, 24, 15, 8, 38, 12],
     wordWrap: true,
   });
 
   for (const l of logs) {
     const date = (l.created_at ?? "").slice(0, 10);
     const score = l.score != null ? String(l.score) : "";
-    table.push([l.id, truncate(l.executed_item_name, 28), l.execution_type, score, date]);
+    table.push([
+      l.id,
+      truncate(l.executed_item_name, 22),
+      l.execution_type,
+      score,
+      projectIdCell(l.project_id),
+      date,
+    ]);
   }
 
   console.log(table.toString());

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -40,6 +40,7 @@ export interface PromptTestConfig {
   evaluators: EvaluatorConfig[];
   response_schema?: Record<string, unknown>;
   dataset_id?: string;
+  project_id?: string;
 }
 
 export class CliError extends Error {

--- a/cli/tests/auth-project.test.ts
+++ b/cli/tests/auth-project.test.ts
@@ -1,0 +1,135 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { runCli } from "./helpers/run-cli.js";
+
+vi.mock("@root-signals/scorable");
+vi.mock("@inquirer/prompts");
+
+// In-memory model of the settings file so set/unset/show round-trip in tests.
+let virtualSettings: Record<string, unknown> = {};
+let fileExists = false;
+
+const mockExistsSync = vi.fn();
+const mockReadFileSync = vi.fn();
+const mockWriteFileSync = vi.fn();
+const mockMkdirSync = vi.fn();
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: (...args: Parameters<typeof actual.existsSync>) => mockExistsSync(...args),
+    readFileSync: (...args: Parameters<typeof actual.readFileSync>) => mockReadFileSync(...args),
+    writeFileSync: (...args: Parameters<typeof actual.writeFileSync>) => mockWriteFileSync(...args),
+    mkdirSync: (...args: Parameters<typeof actual.mkdirSync>) => mockMkdirSync(...args),
+  };
+});
+
+beforeEach(() => {
+  virtualSettings = {};
+  fileExists = false;
+  mockExistsSync.mockImplementation(() => fileExists);
+  mockReadFileSync.mockImplementation(() => JSON.stringify(virtualSettings));
+  mockWriteFileSync.mockImplementation((_path: unknown, data: unknown) => {
+    virtualSettings = JSON.parse(String(data));
+    fileExists = true;
+  });
+  mockMkdirSync.mockReturnValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("auth set-project", () => {
+  it("writes project_id to settings.json", async () => {
+    const result = await runCli(["auth", "set-project", "proj-uuid-123"]);
+    expect(result.exitCode).toBe(0);
+    expect(virtualSettings["project_id"]).toBe("proj-uuid-123");
+    expect(result.stdout).toContain("project_id saved");
+  });
+
+  it("trims whitespace before persisting", async () => {
+    const result = await runCli(["auth", "set-project", "  spaced  "]);
+    expect(result.exitCode).toBe(0);
+    expect(virtualSettings["project_id"]).toBe("spaced");
+  });
+
+  it("preserves api_key when writing project_id", async () => {
+    virtualSettings = { api_key: "key-abc" };
+    fileExists = true;
+    const result = await runCli(["auth", "set-project", "proj-1"]);
+    expect(result.exitCode).toBe(0);
+    expect(virtualSettings).toEqual({ api_key: "key-abc", project_id: "proj-1" });
+  });
+});
+
+describe("auth unset-project", () => {
+  it("removes project_id from settings.json", async () => {
+    virtualSettings = { api_key: "key-abc", project_id: "proj-1" };
+    fileExists = true;
+    const result = await runCli(["auth", "unset-project"]);
+    expect(result.exitCode).toBe(0);
+    expect(virtualSettings).toEqual({ api_key: "key-abc" });
+    expect(result.stdout).toContain("removed");
+  });
+
+  it("is a no-op when project_id is not set", async () => {
+    virtualSettings = { api_key: "key-abc" };
+    fileExists = true;
+    const result = await runCli(["auth", "unset-project"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No project_id was set");
+  });
+});
+
+describe("auth show-project", () => {
+  it("reports 'none' when nothing is set", async () => {
+    vi.unstubAllEnvs();
+    const result = await runCli(["auth", "show-project"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("source: none");
+  });
+
+  it("reports env source when SCORABLE_PROJECT_ID is set", async () => {
+    vi.stubEnv("SCORABLE_PROJECT_ID", "env-uuid");
+    const result = await runCli(["auth", "show-project"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("env-uuid");
+    expect(result.stdout).toContain("source: env");
+  });
+
+  it("reports settings source when persisted", async () => {
+    vi.unstubAllEnvs();
+    virtualSettings = { project_id: "persisted-uuid" };
+    fileExists = true;
+    const result = await runCli(["auth", "show-project"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("persisted-uuid");
+    expect(result.stdout).toContain("source: settings");
+  });
+});
+
+describe("auth logout", () => {
+  it("clears api_key, temporary_api_key and project_id", async () => {
+    virtualSettings = {
+      api_key: "key-abc",
+      temporary_api_key: "tmp-xyz",
+      project_id: "proj-1",
+      other: "kept",
+    };
+    fileExists = true;
+    const result = await runCli(["auth", "logout"]);
+    expect(result.exitCode).toBe(0);
+    expect(virtualSettings).toEqual({ other: "kept" });
+    expect(result.stdout).toContain("Logged out");
+  });
+
+  it("is a no-op when nothing is set", async () => {
+    virtualSettings = {};
+    fileExists = false;
+    const result = await runCli(["auth", "logout"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Already logged out");
+  });
+});

--- a/cli/tests/project-id.test.ts
+++ b/cli/tests/project-id.test.ts
@@ -1,0 +1,106 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolveProjectId, resolveProjectIdValue } from "../src/lib/project-id.js";
+
+const mockExistsSync = vi.fn();
+const mockReadFileSync = vi.fn();
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: (...args: Parameters<typeof actual.existsSync>) => mockExistsSync(...args),
+    readFileSync: (...args: Parameters<typeof actual.readFileSync>) => mockReadFileSync(...args),
+  };
+});
+
+beforeEach(() => {
+  mockExistsSync.mockReturnValue(false);
+  mockReadFileSync.mockReturnValue("{}");
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("resolveProjectId", () => {
+  it("flag wins over env var", () => {
+    vi.stubEnv("SCORABLE_PROJECT_ID", "env-uuid");
+    const r = resolveProjectId("flag-uuid");
+    expect(r.value).toBe("flag-uuid");
+    expect(r.source).toBe("flag");
+  });
+
+  it("flag wins over settings", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ project_id: "settings-uuid" }));
+    const r = resolveProjectId("flag-uuid");
+    expect(r.value).toBe("flag-uuid");
+    expect(r.source).toBe("flag");
+  });
+
+  it("empty-string flag opts out of inherited defaults", () => {
+    vi.stubEnv("SCORABLE_PROJECT_ID", "env-uuid");
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ project_id: "settings-uuid" }));
+    const r = resolveProjectId("");
+    expect(r.value).toBeUndefined();
+    expect(r.source).toBe("flag");
+  });
+
+  it("env var wins over settings", () => {
+    vi.stubEnv("SCORABLE_PROJECT_ID", "env-uuid");
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ project_id: "settings-uuid" }));
+    const r = resolveProjectId(undefined);
+    expect(r.value).toBe("env-uuid");
+    expect(r.source).toBe("env");
+  });
+
+  it("settings used when no flag or env", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ project_id: "settings-uuid" }));
+    const r = resolveProjectId(undefined);
+    expect(r.value).toBe("settings-uuid");
+    expect(r.source).toBe("settings");
+  });
+
+  it("returns none when nothing configured", () => {
+    const r = resolveProjectId(undefined);
+    expect(r.value).toBeUndefined();
+    expect(r.source).toBe("none");
+  });
+
+  it("empty env var is treated as unset", () => {
+    vi.stubEnv("SCORABLE_PROJECT_ID", "");
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ project_id: "settings-uuid" }));
+    const r = resolveProjectId(undefined);
+    expect(r.value).toBe("settings-uuid");
+    expect(r.source).toBe("settings");
+  });
+
+  it("empty settings field is treated as unset", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ project_id: "" }));
+    const r = resolveProjectId(undefined);
+    expect(r.value).toBeUndefined();
+    expect(r.source).toBe("none");
+  });
+
+  it("non-string settings field is treated as unset", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ project_id: 42 }));
+    const r = resolveProjectId(undefined);
+    expect(r.value).toBeUndefined();
+    expect(r.source).toBe("none");
+  });
+});
+
+describe("resolveProjectIdValue", () => {
+  it("returns just the value", () => {
+    expect(resolveProjectIdValue("abc")).toBe("abc");
+    expect(resolveProjectIdValue("")).toBeUndefined();
+    expect(resolveProjectIdValue(undefined)).toBeUndefined();
+  });
+});

--- a/cli/tests/project.test.ts
+++ b/cli/tests/project.test.ts
@@ -1,0 +1,185 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Scorable } from "@root-signals/scorable";
+import { runCli } from "./helpers/run-cli.js";
+
+vi.mock("@root-signals/scorable", async () => {
+  const actual =
+    await vi.importActual<typeof import("@root-signals/scorable")>("@root-signals/scorable");
+  return { ...actual, Scorable: vi.fn() };
+});
+vi.mock("@inquirer/prompts");
+
+const mockList = vi.fn();
+const mockRetrieve = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+
+const sampleProject = {
+  id: "proj-123",
+  name: "Production",
+  description: "Prod env",
+  is_default: true,
+  created_at: "2025-01-01T00:00:00Z",
+  owner: "user-1",
+};
+
+beforeEach(() => {
+  vi.stubEnv("SCORABLE_API_KEY", "test-api-key");
+  vi.mocked(Scorable).mockImplementation(function () {
+    return {
+      projects: {
+        list: mockList,
+        retrieve: mockRetrieve,
+        create: mockCreate,
+        update: mockUpdate,
+        delete: mockDelete,
+      },
+    } as unknown as Scorable;
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("project list", () => {
+  it("lists projects and renders (default) marker", async () => {
+    mockList.mockResolvedValue({
+      results: [
+        sampleProject,
+        {
+          id: "proj-456",
+          name: "Staging",
+          description: "Stage",
+          is_default: false,
+          created_at: "2025-01-02T00:00:00Z",
+          owner: "user-1",
+        },
+      ],
+    });
+    const result = await runCli(["project", "list"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/Production \(default\)/);
+    expect(result.stdout).toContain("Staging");
+    // Staging line must not carry the marker.
+    expect(result.stdout).not.toMatch(/Staging \(default\)/);
+  });
+
+  it("handles empty list", async () => {
+    mockList.mockResolvedValue({ results: [] });
+    const result = await runCli(["project", "list"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No projects found");
+  });
+});
+
+describe("project get", () => {
+  it("fetches a single project", async () => {
+    mockRetrieve.mockResolvedValue(sampleProject);
+    const result = await runCli(["project", "get", "proj-123"]);
+    expect(result.exitCode).toBe(0);
+    expect(mockRetrieve).toHaveBeenCalledWith("proj-123");
+    expect(result.stdout).toContain("proj-123");
+  });
+});
+
+describe("project create", () => {
+  it("creates with just a name", async () => {
+    mockCreate.mockResolvedValue(sampleProject);
+    const result = await runCli(["project", "create", "--name", "Production"]);
+    expect(result.exitCode).toBe(0);
+    expect(mockCreate).toHaveBeenCalledWith({ name: "Production" });
+    expect(result.stdout).toContain("Project created successfully");
+  });
+
+  it("passes description and is_default", async () => {
+    mockCreate.mockResolvedValue(sampleProject);
+    const result = await runCli([
+      "project",
+      "create",
+      "--name",
+      "Production",
+      "--description",
+      "Prod env",
+      "--is-default",
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: "Production",
+      description: "Prod env",
+      is_default: true,
+    });
+  });
+});
+
+describe("project update", () => {
+  it("rejects when no params provided", async () => {
+    const result = await runCli(["project", "update", "proj-123"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No update parameters provided");
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("forwards name and description", async () => {
+    mockUpdate.mockResolvedValue(sampleProject);
+    const result = await runCli([
+      "project",
+      "update",
+      "proj-123",
+      "--name",
+      "Production v2",
+      "--description",
+      "updated",
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(mockUpdate).toHaveBeenCalledWith("proj-123", {
+      name: "Production v2",
+      description: "updated",
+    });
+  });
+
+  it("--is-default sets only is_default: true", async () => {
+    mockUpdate.mockResolvedValue(sampleProject);
+    const result = await runCli(["project", "update", "proj-123", "--is-default"]);
+    expect(result.exitCode).toBe(0);
+    expect(mockUpdate).toHaveBeenCalledWith("proj-123", { is_default: true });
+  });
+});
+
+describe("project set-default", () => {
+  it("PATCHes is_default: true", async () => {
+    mockUpdate.mockResolvedValue(sampleProject);
+    const result = await runCli(["project", "set-default", "proj-123"]);
+    expect(result.exitCode).toBe(0);
+    expect(mockUpdate).toHaveBeenCalledWith("proj-123", { is_default: true });
+  });
+});
+
+describe("project delete", () => {
+  it("deletes with --yes", async () => {
+    mockDelete.mockResolvedValue(undefined);
+    const result = await runCli(["project", "delete", "proj-123", "--yes"]);
+    expect(result.exitCode).toBe(0);
+    expect(mockDelete).toHaveBeenCalledWith("proj-123");
+    expect(result.stdout).toContain("deleted successfully");
+  });
+
+  it("prompts for confirmation interactively", async () => {
+    mockDelete.mockResolvedValue(undefined);
+    const { confirm } = await import("@inquirer/prompts");
+    vi.mocked(confirm).mockResolvedValue(true);
+    const result = await runCli(["project", "delete", "proj-123"]);
+    expect(result.exitCode).toBe(0);
+    expect(mockDelete).toHaveBeenCalledWith("proj-123");
+  });
+
+  it("aborts when user declines", async () => {
+    const { confirm } = await import("@inquirer/prompts");
+    vi.mocked(confirm).mockResolvedValue(false);
+    const result = await runCli(["project", "delete", "proj-123"]);
+    expect(result.exitCode).toBe(1);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds full project hierarchy support to the CLI on top of `@root-signals/scorable@0.11.0` (published from #148).

### What's in

- **New `scorable project` command group**: `list`, `get`, `create`, `update`, `delete`, `set-default`. `create` and `update` accept `--is-default` to promote a project as the org default (atomically clearing the previous default). `project list` appends `(default)` to the default project's name.
- **`--project-id <uuid>` on every project-aware command**: evaluator (`execute`, `execute-by-name`, `create`, `update`, `duplicate`, `import-yaml`, `list`); judge (`execute`, `execute-by-name`, `create`, `update`, `duplicate`, `generate`, `list`, `exec-openai`, `exec-openai-generic`); `execution-log list`. Pass `--project-id ""` to opt out of an inherited default for a single invocation.
- **OpenAI-compat header**: `judge exec-openai` and `judge exec-openai-generic` translate `--project-id` to the `X-Project-Id` HTTP header per request (the OpenAI wire format can't carry it in the body).
- **Resolution order** for every `--project-id`: CLI flag → `SCORABLE_PROJECT_ID` env var → `project_id` in `~/.scorable/settings.json` → omitted.
- **`auth` subcommands for the persistent default**: `auth set-project`, `auth unset-project`, `auth show-project` (prints resolved id + source). `auth logout` clears the saved project_id alongside the api keys.
- **Project ID column** on `evaluator list`, `judge list`, `execution-log list` output (public resources show empty).
- **`prompt-test` config persistence**: `init --project-id` writes the project into the generated config; `run` reads it and accepts `--project-id` to override.
- **`evaluator export-yaml`** strips `project_id` from output (keeps YAML portable across orgs).
- **Error UX**: backend rejections (cross-org project_id, duplicate names, clearing the default) surface as single-line stderr + exit 1 with the backend reason verbatim.

### Out of scope

- `scorable judge claim` (no CLI command exists today).
- TS SDK first-class wrappers for OpenAI-compat endpoints — CLI bypasses the SDK for those and sets the header on the raw fetch.

## Test plan

- [x] `npm run check-all` clean (typecheck, lint, fmt, 240/240 unit tests pass).
- [x] Manual smoke against local backend:
  - [x] `project list` shows default marker
  - [x] `project create --name X --is-default`, `set-default`, `delete` all work
  - [x] `project create` with duplicate name → 409 surfaced verbatim
  - [x] `judge list` and `evaluator list` render Project ID column
  - [x] `judge list --project-id <id>` filter works
  - [x] `judge update <id> --project-id <other>` re-homes the judge
  - [x] `evaluator export-yaml` output contains zero `project_id` references
  - [x] `auth set-project` / `unset-project` / `show-project` roundtrip via `~/.scorable/settings.json`
  - [x] `--project-id` flag overrides `SCORABLE_PROJECT_ID` env var
  - [x] `--project-id ""` opts out of inherited env var
  - [x] `--project-id` documented in `--help` for `exec-openai` / `execute`
- [ ] Reviewer: integration tests in the monorepo (`tests/system/tests/sync/test_cli.py`) ship in a separate PR.

## Follow-ups (not blocking this PR)

- Once the system tests CLI vendor pin advances past this release, merge the corresponding integration test additions PR on the rs monorepo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project management commands: create, list, retrieve, update, delete, and set-default.
  * Project scoping added across judge, evaluator, execution-log, and prompt-test commands via --project-id and auth project defaults (set/unset/show).
  * Export/import and prompt-test behaviors adjusted for portable project_id handling.

* **Documentation**
  * Added Projects section with usage examples, flag precedence, and auth persistence notes.

* **Tests**
  * New test suites covering project commands, project-id resolution, and auth project persistence.

* **Chores**
  * CLI version bumped to 0.14.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->