### PR TITLE
CLI: annotation, dataset-item, and calibration-run commands (0.15.0)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.15.0
+
+- Bump `@root-signals/scorable` to `^0.12.0` for the annotation-store resources.
+- New `scorable dataset-item` command group: `add`, `add-bulk`, `list`, `get`, `update`, `archive` — build labelled datasets programmatically.
+- New `scorable annotation` command group: `create`, `list`, `get`, `update`, `delete`. Label a dataset item (or execution log) with an expected score; omitting `--score-config-id` uses the global identity "Score" config.
+- New `scorable calibration-run` command group: `create`, `get`, `list`, `items` — start a calibration run against a labelled dataset and read its per-example results (human/evaluator scores, disagreement, request/response).
+- New `scorable evaluator calibrate <id> --dataset-id <id>` to start a calibration run for a saved evaluator.
+- `evaluator create` / `evaluator update` accept `--demonstration-dataset <id>` to attach a labelled dataset as few-shot demonstrations.
+
 ## 0.14.0
 
 - Bump `@root-signals/scorable` to `^0.11.0` for the new `projects` resource and `projectId` support.

--- a/cli/README.md
+++ b/cli/README.md
@@ -336,6 +336,59 @@ scorable evaluator execute-by-name "My Evaluator" --request "What is 2+2?" --res
 
 Accepts the same options as `execute`, including `--variables`.
 
+## Labelling & Calibration
+
+Build a labelled dataset, then calibrate a saved evaluator against it to measure how well it agrees with your expected scores.
+
+### Dataset items
+
+Populate a `test`-type dataset with request/response items.
+
+```bash
+scorable dataset-item add <dataset_id> --response "Paris" --request "Capital of France?"
+scorable dataset-item add-bulk <dataset_id> --items '[{"response":"Paris","request":"Capital of France?"}]'
+scorable dataset-item list <dataset_id>                       # latest-version items (with embedded annotations)
+scorable dataset-item list <dataset_id> --include-archived
+scorable dataset-item get <dataset_id> <item_id>
+scorable dataset-item update <dataset_id> <item_id> --response "Paris, France"
+scorable dataset-item archive <dataset_id> <item_id>
+```
+
+### Annotations
+
+Label a dataset item (or execution log) with an expected score. Omitting `--score-config-id` uses the global identity "Score" config, so a raw expected score can be set with just `--value`.
+
+```bash
+scorable annotation create --dataset-item-id <item_id> --value 0.9
+scorable annotation create --dataset-item-id <item_id> --category "👍" --score-config-id <config_id>
+scorable annotation list --dataset <dataset_id>
+scorable annotation get <annotation_id>
+scorable annotation update <annotation_id> --value 0.8
+scorable annotation delete <annotation_id>
+```
+
+### Calibration runs
+
+Start a calibration run against a labelled dataset and read its per-example results (human vs. evaluator score, disagreement, and the request/response that was scored).
+
+```bash
+scorable evaluator calibrate <evaluator_id> --dataset-id <dataset_id>
+# ...or the equivalent calibration-run command:
+scorable calibration-run create --evaluator-id <evaluator_id> --dataset-id <dataset_id>
+scorable calibration-run get <run_id>                         # poll for status + metrics
+scorable calibration-run list --evaluator-id <evaluator_id>
+scorable calibration-run items <run_id>                       # per-example results
+```
+
+### Demonstrations
+
+Attach a labelled dataset as few-shot demonstrations on an evaluator.
+
+```bash
+scorable evaluator create --name "My Evaluator" ... --demonstration-dataset <dataset_id>
+scorable evaluator update <evaluator_id> --demonstration-dataset <dataset_id>
+```
+
 ## Custom Model Management
 
 Bring your own LLM (BYO-LLM) — register a custom or self-hosted model, then reference it from evaluators and judges.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@root-signals/scorable-cli",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@root-signals/scorable": "^0.11.0",
+        "@root-signals/scorable": "^0.12.0",
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "commander": "^15.0.0",
@@ -1353,9 +1353,9 @@
       "license": "MIT"
     },
     "node_modules/@root-signals/scorable": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.11.0.tgz",
-      "integrity": "sha512-DuGI39YHi2ZOO5kRYgvJbvsBNxBS642Pkg2rNq0sz3mSdhJvCvr3nlrzMkNK0NVPMOSy5oDoExVzG8HVPNGiTw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.12.0.tgz",
+      "integrity": "sha512-2RSNaEVf0QmC+Q79IWDqxCgxuZRZqoFoHBLy/FdQ4uCTkBG9mApmwlaLbzKzZlBqxnztck7Ji9P7rvUOmKAoWQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.15.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",
-    "@root-signals/scorable": "^0.11.0",
+    "@root-signals/scorable": "^0.12.0",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^15.0.0",

--- a/cli/src/commands/annotation/index.ts
+++ b/cli/src/commands/annotation/index.ts
@@ -1,0 +1,168 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
+import type { CreateAnnotationData, AnnotationListParams } from "@root-signals/scorable";
+
+export function registerAnnotationCommands(program: Command): void {
+  const annotation = new Command("annotation").description("Annotation (labelling) commands");
+
+  annotation
+    .command("create")
+    .description("Create an annotation on a dataset item or execution log")
+    .option(
+      "--dataset-item-id <id>",
+      "Dataset item to annotate (mutually exclusive with --execution-log-id)",
+    )
+    .option(
+      "--execution-log-id <id>",
+      "Execution log to annotate (mutually exclusive with --dataset-item-id)",
+    )
+    .option("--value <number>", "Score for continuous configs", parseFloat)
+    .option("--category <label>", "Label for binary/categorical configs")
+    .option("--rationale <text>", "Optional free-text justification")
+    .option("--status <status>", "draft or published (default published)")
+    .option(
+      "--score-config-id <id>",
+      "Score config; defaults to the global identity 'Score' config",
+    )
+    .action(
+      async (opts: {
+        datasetItemId?: string;
+        executionLogId?: string;
+        value?: number;
+        category?: string;
+        rationale?: string;
+        status?: string;
+        scoreConfigId?: string;
+      }) => {
+        if (!opts.datasetItemId === !opts.executionLogId) {
+          printError("Exactly one of --dataset-item-id or --execution-log-id must be provided.");
+          return;
+        }
+        const payload: CreateAnnotationData = {};
+        if (opts.datasetItemId) payload.datasetItemId = opts.datasetItemId;
+        if (opts.executionLogId) payload.executionLogId = opts.executionLogId;
+        if (opts.value !== undefined) payload.value = opts.value;
+        if (opts.category !== undefined) payload.category = opts.category;
+        if (opts.rationale !== undefined) payload.rationale = opts.rationale;
+        if (opts.status !== undefined)
+          payload.status = opts.status as CreateAnnotationData["status"];
+        if (opts.scoreConfigId) payload.scoreConfigId = opts.scoreConfigId;
+
+        const spinner = ora("Creating annotation...").start();
+        try {
+          const client = getSdkClient(await requireApiKey());
+          const result = await client.annotations.create(payload);
+          spinner.stop();
+          printSuccess("Annotation created!");
+          printJson(result);
+        } catch (e) {
+          spinner.stop();
+          handleSdkError(e);
+        }
+      },
+    );
+
+  annotation
+    .command("list")
+    .description("List annotations")
+    .option("--dataset <id>", "Filter by the dataset the annotated items belong to")
+    .option("--score-config <id>", "Filter by score config id")
+    .option("--status <status>", "Filter by draft or published")
+    .option("--dataset-item <id>", "Filter by dataset item id")
+    .option("--execution-log <id>", "Filter by execution log id")
+    .action(
+      async (opts: {
+        dataset?: string;
+        scoreConfig?: string;
+        status?: string;
+        datasetItem?: string;
+        executionLog?: string;
+      }) => {
+        const params: AnnotationListParams = {};
+        if (opts.dataset) params.dataset = opts.dataset;
+        if (opts.scoreConfig) params.score_config = opts.scoreConfig;
+        if (opts.status) params.status = opts.status as AnnotationListParams["status"];
+        if (opts.datasetItem) params.dataset_item = opts.datasetItem;
+        if (opts.executionLog) params.execution_log = opts.executionLog;
+
+        const spinner = ora("Listing annotations...").start();
+        try {
+          const client = getSdkClient(await requireApiKey());
+          const result = await client.annotations.list(params);
+          spinner.stop();
+          printJson(result.results);
+        } catch (e) {
+          spinner.stop();
+          handleSdkError(e);
+        }
+      },
+    );
+
+  annotation
+    .command("get <id>")
+    .description("Get an annotation by ID")
+    .action(async (id: string) => {
+      const spinner = ora("Fetching annotation...").start();
+      try {
+        const client = getSdkClient(await requireApiKey());
+        const result = await client.annotations.get(id);
+        spinner.stop();
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+
+  annotation
+    .command("update <id>")
+    .description("Update an annotation (target is immutable)")
+    .option("--value <number>", "New score for continuous configs", parseFloat)
+    .option("--category <label>", "New label for binary/categorical configs")
+    .option("--rationale <text>", "New rationale")
+    .option("--status <status>", "draft or published")
+    .action(
+      async (
+        id: string,
+        opts: { value?: number; category?: string; rationale?: string; status?: string },
+      ) => {
+        const payload: Parameters<ReturnType<typeof getSdkClient>["annotations"]["update"]>[1] = {};
+        if (opts.value !== undefined) payload.value = opts.value;
+        if (opts.category !== undefined) payload.category = opts.category;
+        if (opts.rationale !== undefined) payload.rationale = opts.rationale;
+        if (opts.status !== undefined) payload.status = opts.status as typeof payload.status;
+
+        const spinner = ora("Updating annotation...").start();
+        try {
+          const client = getSdkClient(await requireApiKey());
+          const result = await client.annotations.update(id, payload);
+          spinner.stop();
+          printSuccess("Annotation updated!");
+          printJson(result);
+        } catch (e) {
+          spinner.stop();
+          handleSdkError(e);
+        }
+      },
+    );
+
+  annotation
+    .command("delete <id>")
+    .description("Delete an annotation")
+    .action(async (id: string) => {
+      const spinner = ora("Deleting annotation...").start();
+      try {
+        const client = getSdkClient(await requireApiKey());
+        await client.annotations.delete(id);
+        spinner.stop();
+        printSuccess(`Annotation ${id} deleted.`);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+
+  program.addCommand(annotation);
+}

--- a/cli/src/commands/calibration-run/index.ts
+++ b/cli/src/commands/calibration-run/index.ts
@@ -1,0 +1,88 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, printJson, handleSdkError } from "../../output.js";
+import type { CreateCalibrationRunData } from "@root-signals/scorable";
+
+export function registerCalibrationRunCommands(program: Command): void {
+  const run = new Command("calibration-run").description("Calibration run commands");
+
+  run
+    .command("create")
+    .description("Start a calibration run against a labelled dataset")
+    .requiredOption("--evaluator-id <id>", "The saved evaluator to calibrate")
+    .requiredOption("--dataset-id <id>", "Dataset whose published annotations to calibrate against")
+    .option("--score-config-id <id>", "Score config (defaults to the dataset's continuous scores)")
+    .action(async (opts: { evaluatorId: string; datasetId: string; scoreConfigId?: string }) => {
+      const payload: CreateCalibrationRunData = {
+        evaluatorId: opts.evaluatorId,
+        datasetId: opts.datasetId,
+      };
+      if (opts.scoreConfigId) payload.scoreConfigId = opts.scoreConfigId;
+
+      const spinner = ora("Starting calibration run...").start();
+      try {
+        const client = getSdkClient(await requireApiKey());
+        const result = await client.calibrationRuns.create(payload);
+        spinner.stop();
+        printSuccess(`Calibration run ${result.id} started (status: ${result.status}).`);
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+
+  run
+    .command("get <id>")
+    .description("Get a calibration run (poll for status and metrics)")
+    .action(async (id: string) => {
+      const spinner = ora("Fetching calibration run...").start();
+      try {
+        const client = getSdkClient(await requireApiKey());
+        const result = await client.calibrationRuns.get(id);
+        spinner.stop();
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+
+  run
+    .command("list")
+    .description("List calibration runs")
+    .option("--evaluator-id <id>", "Filter by evaluator external id")
+    .action(async (opts: { evaluatorId?: string }) => {
+      const spinner = ora("Listing calibration runs...").start();
+      try {
+        const client = getSdkClient(await requireApiKey());
+        const result = await client.calibrationRuns.list(
+          opts.evaluatorId ? { evaluatorId: opts.evaluatorId } : {},
+        );
+        spinner.stop();
+        printJson(result.results);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+
+  run
+    .command("items <id>")
+    .description("List the per-example results of a calibration run")
+    .action(async (id: string) => {
+      const spinner = ora("Fetching calibration run items...").start();
+      try {
+        const client = getSdkClient(await requireApiKey());
+        const result = await client.calibrationRuns.listItems(id);
+        spinner.stop();
+        printJson(result.results);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+
+  program.addCommand(run);
+}

--- a/cli/src/commands/dataset-item/index.ts
+++ b/cli/src/commands/dataset-item/index.ts
@@ -1,0 +1,181 @@
+import { Command } from "commander";
+import ora from "ora";
+import { z } from "zod";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, printError, printJson, handleSdkError } from "../../output.js";
+import { parseJsonArg } from "../../utils.js";
+import type { DatasetItemRequest, PatchedDatasetItemRequest } from "@root-signals/scorable";
+
+export function registerDatasetItemCommands(program: Command): void {
+  const item = new Command("dataset-item").description("Dataset item commands");
+
+  item
+    .command("add <datasetId>")
+    .description("Add a single item to a dataset")
+    .requiredOption("--response <text>", "The response text")
+    .option("--request <text>", "The request/prompt text")
+    .option("--expected-output <text>", "The expected output")
+    .option("--metadata <json>", "Metadata JSON object")
+    .option("--change-note <text>", "Change note for this version")
+    .action(
+      async (
+        datasetId: string,
+        opts: {
+          response: string;
+          request?: string;
+          expectedOutput?: string;
+          metadata?: string;
+          changeNote?: string;
+        },
+      ) => {
+        const body: DatasetItemRequest = { response: opts.response };
+        if (opts.request !== undefined) body.request = opts.request;
+        if (opts.expectedOutput !== undefined) body.expected_output = opts.expectedOutput;
+        if (opts.changeNote !== undefined) body.change_note = opts.changeNote;
+        if (opts.metadata !== undefined) {
+          const r = parseJsonArg(opts.metadata, z.record(z.string(), z.unknown()));
+          if (!r.ok) {
+            printError("Invalid JSON for --metadata. Expected an object.");
+            return;
+          }
+          body.metadata = r.value;
+        }
+
+        const spinner = ora("Adding item...").start();
+        try {
+          const client = getSdkClient(await requireApiKey());
+          const result = await client.datasets.addItem(datasetId, body);
+          spinner.stop();
+          printSuccess("Dataset item added!");
+          printJson(result);
+        } catch (e) {
+          spinner.stop();
+          handleSdkError(e);
+        }
+      },
+    );
+
+  item
+    .command("add-bulk <datasetId>")
+    .description("Bulk add items to a dataset (at most 5000)")
+    .requiredOption("--items <json>", "JSON array of item objects")
+    .action(async (datasetId: string, opts: { items: string }) => {
+      const r = parseJsonArg(opts.items, z.array(z.record(z.string(), z.unknown())));
+      if (!r.ok) {
+        printError("Invalid JSON for --items. Expected an array of item objects.");
+        return;
+      }
+      const spinner = ora("Bulk adding items...").start();
+      try {
+        const client = getSdkClient(await requireApiKey());
+        const result = await client.datasets.addItems(datasetId, r.value as DatasetItemRequest[]);
+        spinner.stop();
+        printSuccess(`Added ${result.length} dataset items.`);
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+
+  item
+    .command("list <datasetId>")
+    .description("List the latest-version items of a dataset (with embedded annotations)")
+    .option("--include-archived", "Include archived items", false)
+    .action(async (datasetId: string, opts: { includeArchived?: boolean }) => {
+      const spinner = ora("Listing items...").start();
+      try {
+        const client = getSdkClient(await requireApiKey());
+        const result = await client.datasets.listItems(datasetId, {
+          includeArchived: opts.includeArchived ?? false,
+        });
+        spinner.stop();
+        printJson(result.results);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+
+  item
+    .command("get <datasetId> <itemId>")
+    .description("Get a single dataset item")
+    .action(async (datasetId: string, itemId: string) => {
+      const spinner = ora("Fetching item...").start();
+      try {
+        const client = getSdkClient(await requireApiKey());
+        const result = await client.datasets.getItem(datasetId, itemId);
+        spinner.stop();
+        printJson(result);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+
+  item
+    .command("update <datasetId> <itemId>")
+    .description("Edit a dataset item (creates a new version)")
+    .option("--response <text>", "The response text")
+    .option("--request <text>", "The request/prompt text")
+    .option("--expected-output <text>", "The expected output")
+    .option("--metadata <json>", "Metadata JSON object")
+    .option("--change-note <text>", "Change note for this version")
+    .action(
+      async (
+        datasetId: string,
+        itemId: string,
+        opts: {
+          response?: string;
+          request?: string;
+          expectedOutput?: string;
+          metadata?: string;
+          changeNote?: string;
+        },
+      ) => {
+        const body: PatchedDatasetItemRequest = {};
+        if (opts.response !== undefined) body.response = opts.response;
+        if (opts.request !== undefined) body.request = opts.request;
+        if (opts.expectedOutput !== undefined) body.expected_output = opts.expectedOutput;
+        if (opts.changeNote !== undefined) body.change_note = opts.changeNote;
+        if (opts.metadata !== undefined) {
+          const r = parseJsonArg(opts.metadata, z.record(z.string(), z.unknown()));
+          if (!r.ok) {
+            printError("Invalid JSON for --metadata. Expected an object.");
+            return;
+          }
+          body.metadata = r.value;
+        }
+
+        const spinner = ora("Updating item...").start();
+        try {
+          const client = getSdkClient(await requireApiKey());
+          const result = await client.datasets.updateItem(datasetId, itemId, body);
+          spinner.stop();
+          printSuccess("Dataset item updated!");
+          printJson(result);
+        } catch (e) {
+          spinner.stop();
+          handleSdkError(e);
+        }
+      },
+    );
+
+  item
+    .command("archive <datasetId> <itemId>")
+    .description("Archive (soft-delete) a dataset item")
+    .action(async (datasetId: string, itemId: string) => {
+      const spinner = ora("Archiving item...").start();
+      try {
+        const client = getSdkClient(await requireApiKey());
+        await client.datasets.archiveItem(datasetId, itemId);
+        spinner.stop();
+        printSuccess(`Dataset item ${itemId} archived.`);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+
+  program.addCommand(item);
+}

--- a/cli/src/commands/evaluator/calibrate.ts
+++ b/cli/src/commands/evaluator/calibrate.ts
@@ -1,0 +1,35 @@
+import { Command } from "commander";
+import ora from "ora";
+import { requireApiKey, getSdkClient } from "../../auth.js";
+import { printSuccess, printJson, handleSdkError } from "../../output.js";
+
+export function registerCalibrateCommand(evaluator: Command): void {
+  evaluator
+    .command("calibrate <evaluatorId>")
+    .description("Start a calibration run for a saved evaluator against a labelled dataset")
+    .requiredOption("--dataset-id <id>", "Dataset whose published annotations to calibrate against")
+    .option(
+      "--score-config-id <id>",
+      "Score config to calibrate against (defaults to the dataset's continuous scores)",
+    )
+    .action(async (evaluatorId: string, opts: { datasetId: string; scoreConfigId?: string }) => {
+      const apiKey = await requireApiKey();
+      const spinner = ora("Starting calibration run...").start();
+      try {
+        const client = getSdkClient(apiKey);
+        const run = await client.evaluators.calibrateRun(evaluatorId, {
+          datasetId: opts.datasetId,
+          ...(opts.scoreConfigId !== undefined ? { scoreConfigId: opts.scoreConfigId } : {}),
+        });
+        spinner.stop();
+        printSuccess(
+          `Calibration run ${run.id} started (status: ${run.status}). ` +
+            `Poll 'scorable calibration-run get ${run.id}' for metrics.`,
+        );
+        printJson(run);
+      } catch (e) {
+        spinner.stop();
+        handleSdkError(e);
+      }
+    });
+}

--- a/cli/src/commands/evaluator/create.ts
+++ b/cli/src/commands/evaluator/create.ts
@@ -27,6 +27,10 @@ export function registerCreateCommand(evaluator: Command): void {
     )
     .option("--overwrite", "Overwrite if evaluator with same name exists")
     .option("--objective-version-id <id>", "Objective version ID")
+    .option(
+      "--demonstration-dataset <id>",
+      "Dataset of labelled examples resolved into few-shot demonstrations at evaluation time.",
+    )
     .option("--project-id <uuid>", PROJECT_ID_FLAG_DESC)
     .action(
       async (opts: {
@@ -37,6 +41,7 @@ export function registerCreateCommand(evaluator: Command): void {
         models?: string;
         overwrite?: boolean;
         objectiveVersionId?: string;
+        demonstrationDataset?: string;
         projectId?: string;
       }) => {
         if (!opts.intent && !opts.objectiveId) {
@@ -64,6 +69,7 @@ export function registerCreateCommand(evaluator: Command): void {
         if (opts.objectiveId) payload.objective_id = opts.objectiveId;
         if (opts.overwrite !== undefined) payload.overwrite = opts.overwrite;
         if (opts.objectiveVersionId) payload.objective_version_id = opts.objectiveVersionId;
+        if (opts.demonstrationDataset) payload.demonstration_dataset_id = opts.demonstrationDataset;
 
         if (opts.models) {
           const r = parseJsonArg(opts.models, z.array(z.string()));

--- a/cli/src/commands/evaluator/index.ts
+++ b/cli/src/commands/evaluator/index.ts
@@ -9,6 +9,7 @@ import { registerExecuteByNameCommand } from "./execute-by-name.js";
 import { registerDuplicateCommand } from "./duplicate.js";
 import { registerExportYamlCommand } from "./export-yaml.js";
 import { registerImportYamlCommand } from "./import-yaml.js";
+import { registerCalibrateCommand } from "./calibrate.js";
 
 export function registerEvaluatorCommands(program: Command): void {
   const evaluator = new Command("evaluator").description("Evaluator management commands");
@@ -23,6 +24,7 @@ export function registerEvaluatorCommands(program: Command): void {
   registerDuplicateCommand(evaluator);
   registerExportYamlCommand(evaluator);
   registerImportYamlCommand(evaluator);
+  registerCalibrateCommand(evaluator);
 
   program.addCommand(evaluator);
 }

--- a/cli/src/commands/evaluator/update.ts
+++ b/cli/src/commands/evaluator/update.ts
@@ -17,6 +17,10 @@ export function registerUpdateCommand(evaluator: Command): void {
     .option("--objective-id <id>", "The new objective ID")
     .option("--objective-version-id <id>", "The new objective version ID")
     .option(
+      "--demonstration-dataset <id>",
+      "Dataset of labelled examples resolved into few-shot demonstrations at evaluation time.",
+    )
+    .option(
       "--project-id <uuid>",
       "Move the evaluator to this project (within the same organization). " + PROJECT_ID_FLAG_DESC,
     )
@@ -29,6 +33,7 @@ export function registerUpdateCommand(evaluator: Command): void {
           models?: string;
           objectiveId?: string;
           objectiveVersionId?: string;
+          demonstrationDataset?: string;
           projectId?: string;
         },
       ) => {
@@ -40,6 +45,8 @@ export function registerUpdateCommand(evaluator: Command): void {
         if (opts.objectiveId !== undefined) payload.objective_id = opts.objectiveId;
         if (opts.objectiveVersionId !== undefined)
           payload.objective_version_id = opts.objectiveVersionId;
+        if (opts.demonstrationDataset !== undefined)
+          payload.demonstration_dataset_id = opts.demonstrationDataset;
 
         if (opts.models !== undefined) {
           const r = parseJsonArg(opts.models, z.array(z.string()));

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -15,6 +15,9 @@ import { registerOtelFilterCommands } from "./commands/otel-filter/index.js";
 import { registerOtelTraceCommands } from "./commands/otel-trace/index.js";
 import { registerModelCommands } from "./commands/model/index.js";
 import { registerProjectCommands } from "./commands/project/index.js";
+import { registerAnnotationCommands } from "./commands/annotation/index.js";
+import { registerCalibrationRunCommands } from "./commands/calibration-run/index.js";
+import { registerDatasetItemCommands } from "./commands/dataset-item/index.js";
 
 const { version } = createRequire(import.meta.url)("../package.json") as {
   version: string;
@@ -85,6 +88,9 @@ export function createCli(): Command {
   registerOtelTraceCommands(program);
   registerModelCommands(program);
   registerProjectCommands(program);
+  registerAnnotationCommands(program);
+  registerCalibrationRunCommands(program);
+  registerDatasetItemCommands(program);
 
   return program;
 }

--- a/cli/tests/annotation.test.ts
+++ b/cli/tests/annotation.test.ts
@@ -1,0 +1,82 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Scorable } from "@root-signals/scorable";
+import { runCli } from "./helpers/run-cli.js";
+
+vi.mock("@root-signals/scorable");
+vi.mock("@inquirer/prompts");
+vi.mock("node:fs");
+
+const mockCreate = vi.fn();
+const mockList = vi.fn();
+const mockGet = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+
+beforeEach(() => {
+  vi.stubEnv("SCORABLE_API_KEY", "test-api-key");
+  vi.mocked(Scorable).mockImplementation(function () {
+    return {
+      annotations: {
+        create: mockCreate,
+        list: mockList,
+        get: mockGet,
+        update: mockUpdate,
+        delete: mockDelete,
+      },
+    } as unknown as Scorable;
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("annotation create", () => {
+  it("creates an annotation on a dataset item", async () => {
+    mockCreate.mockResolvedValue({ id: "ann-1", value: 1.0 });
+
+    const result = await runCli([
+      "annotation",
+      "create",
+      "--dataset-item-id",
+      "di-1",
+      "--category",
+      "👍",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ datasetItemId: "di-1", category: "👍" }),
+    );
+  });
+
+  it("rejects when no target is provided", async () => {
+    const result = await runCli(["annotation", "create", "--value", "0.5"]);
+
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(result.stderr).toMatch(/exactly one of --dataset-item-id or --execution-log-id/i);
+  });
+});
+
+describe("annotation list", () => {
+  it("forwards filters", async () => {
+    mockList.mockResolvedValue({ results: [{ id: "ann-1" }] });
+
+    await runCli(["annotation", "list", "--dataset", "ds-1", "--status", "published"]);
+
+    expect(mockList).toHaveBeenCalledWith(
+      expect.objectContaining({ dataset: "ds-1", status: "published" }),
+    );
+  });
+});
+
+describe("annotation delete", () => {
+  it("deletes an annotation", async () => {
+    mockDelete.mockResolvedValue(undefined);
+
+    await runCli(["annotation", "delete", "ann-1"]);
+
+    expect(mockDelete).toHaveBeenCalledWith("ann-1");
+  });
+});

--- a/cli/tests/calibration-run.test.ts
+++ b/cli/tests/calibration-run.test.ts
@@ -1,0 +1,69 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Scorable } from "@root-signals/scorable";
+import { runCli } from "./helpers/run-cli.js";
+
+vi.mock("@root-signals/scorable");
+vi.mock("@inquirer/prompts");
+vi.mock("node:fs");
+
+const mockCreate = vi.fn();
+const mockGet = vi.fn();
+const mockList = vi.fn();
+const mockListItems = vi.fn();
+
+beforeEach(() => {
+  vi.stubEnv("SCORABLE_API_KEY", "test-api-key");
+  vi.mocked(Scorable).mockImplementation(function () {
+    return {
+      calibrationRuns: {
+        create: mockCreate,
+        get: mockGet,
+        list: mockList,
+        listItems: mockListItems,
+      },
+    } as unknown as Scorable;
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("calibration-run create", () => {
+  it("starts a run against a dataset", async () => {
+    mockCreate.mockResolvedValue({ id: "run-1", status: "pending" });
+
+    const result = await runCli([
+      "calibration-run",
+      "create",
+      "--evaluator-id",
+      "ev-1",
+      "--dataset-id",
+      "ds-1",
+      "--score-config-id",
+      "sc-1",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(mockCreate).toHaveBeenCalledWith({
+      evaluatorId: "ev-1",
+      datasetId: "ds-1",
+      scoreConfigId: "sc-1",
+    });
+  });
+});
+
+describe("calibration-run get / items", () => {
+  it("gets a run", async () => {
+    mockGet.mockResolvedValue({ id: "run-1", status: "completed" });
+    await runCli(["calibration-run", "get", "run-1"]);
+    expect(mockGet).toHaveBeenCalledWith("run-1");
+  });
+
+  it("lists items", async () => {
+    mockListItems.mockResolvedValue({ results: [{ id: "i-1" }] });
+    await runCli(["calibration-run", "items", "run-1"]);
+    expect(mockListItems).toHaveBeenCalledWith("run-1");
+  });
+});

--- a/cli/tests/dataset-item.test.ts
+++ b/cli/tests/dataset-item.test.ts
@@ -1,0 +1,89 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Scorable } from "@root-signals/scorable";
+import { runCli } from "./helpers/run-cli.js";
+
+vi.mock("@root-signals/scorable");
+vi.mock("@inquirer/prompts");
+vi.mock("node:fs");
+
+const mockAddItem = vi.fn();
+const mockAddItems = vi.fn();
+const mockListItems = vi.fn();
+const mockArchiveItem = vi.fn();
+
+beforeEach(() => {
+  vi.stubEnv("SCORABLE_API_KEY", "test-api-key");
+  vi.mocked(Scorable).mockImplementation(function () {
+    return {
+      datasets: {
+        addItem: mockAddItem,
+        addItems: mockAddItems,
+        listItems: mockListItems,
+        archiveItem: mockArchiveItem,
+      },
+    } as unknown as Scorable;
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("dataset-item add", () => {
+  it("adds a single item", async () => {
+    mockAddItem.mockResolvedValue({ id: "di-1" });
+
+    const result = await runCli([
+      "dataset-item",
+      "add",
+      "ds-1",
+      "--response",
+      "A.",
+      "--metadata",
+      '{"src":"manual"}',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(mockAddItem).toHaveBeenCalledWith(
+      "ds-1",
+      expect.objectContaining({ response: "A.", metadata: { src: "manual" } }),
+    );
+  });
+});
+
+describe("dataset-item add-bulk", () => {
+  it("bulk adds items from JSON", async () => {
+    mockAddItems.mockResolvedValue([{ id: "di-1" }, { id: "di-2" }]);
+
+    await runCli([
+      "dataset-item",
+      "add-bulk",
+      "ds-1",
+      "--items",
+      '[{"response":"r0"},{"response":"r1"}]',
+    ]);
+
+    expect(mockAddItems).toHaveBeenCalledWith("ds-1", [{ response: "r0" }, { response: "r1" }]);
+  });
+});
+
+describe("dataset-item list", () => {
+  it("excludes archived by default", async () => {
+    mockListItems.mockResolvedValue({ results: [{ id: "di-1" }] });
+
+    await runCli(["dataset-item", "list", "ds-1"]);
+
+    expect(mockListItems).toHaveBeenCalledWith("ds-1", { includeArchived: false });
+  });
+});
+
+describe("dataset-item archive", () => {
+  it("archives an item", async () => {
+    mockArchiveItem.mockResolvedValue(undefined);
+
+    await runCli(["dataset-item", "archive", "ds-1", "di-1"]);
+
+    expect(mockArchiveItem).toHaveBeenCalledWith("ds-1", "di-1");
+  });
+});

--- a/cli/tests/evaluator-calibrate.test.ts
+++ b/cli/tests/evaluator-calibrate.test.ts
@@ -1,0 +1,64 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Scorable } from "@root-signals/scorable";
+import { runCli } from "./helpers/run-cli.js";
+
+vi.mock("@root-signals/scorable");
+vi.mock("@inquirer/prompts");
+vi.mock("node:fs");
+
+const mockCalibrateRun = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+
+beforeEach(() => {
+  vi.stubEnv("SCORABLE_API_KEY", "test-api-key");
+  vi.mocked(Scorable).mockImplementation(function () {
+    return {
+      evaluators: {
+        calibrateRun: mockCalibrateRun,
+        create: mockCreate,
+        update: mockUpdate,
+      },
+    } as unknown as Scorable;
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("evaluator calibrate", () => {
+  it("starts a calibration run", async () => {
+    mockCalibrateRun.mockResolvedValue({ id: "run-1", status: "pending" });
+
+    const result = await runCli([
+      "evaluator",
+      "calibrate",
+      "ev-1",
+      "--dataset-id",
+      "ds-1",
+      "--score-config-id",
+      "sc-1",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(mockCalibrateRun).toHaveBeenCalledWith("ev-1", {
+      datasetId: "ds-1",
+      scoreConfigId: "sc-1",
+    });
+  });
+});
+
+describe("evaluator update --demonstration-dataset", () => {
+  it("sends demonstration_dataset_id", async () => {
+    mockUpdate.mockResolvedValue({ id: "ev-1" });
+
+    await runCli(["evaluator", "update", "ev-1", "--demonstration-dataset", "ds-1"]);
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "ev-1",
+      expect.objectContaining({ demonstration_dataset_id: "ds-1" }),
+    );
+  });
+});


### PR DESCRIPTION
Adds CLI coverage for the annotation-store features, on top of the published SDK 0.12.0.

## New commands
- **`scorable dataset-item`** — `add`, `add-bulk`, `list`, `get`, `update`, `archive` (build labelled datasets)
- **`scorable annotation`** — `create`, `list`, `get`, `update`, `delete`. Omitting `--score-config-id` uses the global identity "Score" config, so a raw expected score can be set with just `--value`.
- **`scorable calibration-run`** — `create`, `get`, `list`, `items` (per-example results: human/evaluator score, disagreement, request/response)
- **`scorable evaluator calibrate <id> --dataset-id`**, and `evaluator create` / `update --demonstration-dataset <id>`

## Release
- Bumped `@root-signals/scorable` `^0.11.0` → **`^0.12.0`** and CLI version `0.14.0` → **`0.15.0`** (lockfile refreshed against the published 0.12.0).
- Documented all new commands in `README.md` (new "Labelling & Calibration" section) and `CHANGELOG.md`.

## Verification
- `typecheck`, `lint`, `fmt:check`, and **253 unit tests** pass (tests included for each new command group).
- **Exercised against a live backend**: `dataset-item add`/`list`, `annotation create`/`list` (confirmed the identity-config default), `calibration-run list`/`get`, and `evaluator calibrate` (submits a run) all work end-to-end. (A run can't *complete* on the local backend — its LLM proxy is placeholder-only — but the item serializer fields are covered by the SDK schema + backend tests.)

Follow-up to the SDK 1.13.0 / 0.12.0 release. Publish `@root-signals/scorable-cli` 0.15.0 to npm after merge, then I'll cut the `cli-v0.15.0` tag + GitHub release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI commands for managing dataset items and annotations, including creation, listing, updates, retrieval, and archiving.
  * Added calibration run commands to create, inspect, list, and view per-example results.
  * Added `evaluator calibrate` for launching calibration runs.
  * Evaluators can now use a demonstration dataset during creation or updates.
* **Documentation**
  * Added guidance and examples for labelling datasets and running calibrations.
* **Chores**
  * Updated the CLI to version 0.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->