### PR TITLE
Translate execution-log filter params onto the API's query names

### DIFF
--- a/typescript/src/resources/execution-logs.ts
+++ b/typescript/src/resources/execution-logs.ts
@@ -25,6 +25,41 @@ export interface ExecutionLogListParams extends ListParams {
   projectId?: string;
 }
 
+type ExecutionLogQuery = NonNullable<paths['/v1/execution-logs/']['get']['parameters']['query']>;
+
+/**
+ * Translate the SDK's public filter names onto the API's actual query param
+ * names. Historically several params were forwarded verbatim under names the
+ * API never accepted, which now hard-400 against the strict param gate.
+ */
+function toExecutionLogQuery(params: ExecutionLogListParams): ExecutionLogQuery {
+  const query: Record<string, unknown> = {};
+  const set = (key: string, value: unknown): void => {
+    if (value !== undefined) query[key] = value;
+  };
+
+  // executed_item_id backs both the skill and evaluator filters — an evaluator's
+  // own logs carry its id there — so the two are mutually exclusive in practice.
+  set('executed_item_id', params.skill_id ?? params.evaluator_id);
+  set('judge_id', params.judge_id);
+  set('min_cost', params.cost_min);
+  set('max_cost', params.cost_max);
+  set('min_score', params.score_min);
+  set('max_score', params.score_max);
+  set('date_from', params.created_at_after);
+  set('date_to', params.created_at_before);
+  set('model', params.model);
+  set('owner_email', params.owner__email);
+  set('tags', params.tags);
+  set('search', params.search);
+  set('ordering', params.ordering);
+  set('page_size', params.page_size);
+  set('cursor', params.cursor);
+  set('project_id', params.projectId);
+
+  return query as ExecutionLogQuery;
+}
+
 export class ExecutionLogsResource {
   constructor(private _client: Client) {}
 
@@ -32,8 +67,7 @@ export class ExecutionLogsResource {
    * List execution logs with filtering and pagination
    */
   async list(params: ExecutionLogListParams = {}): Promise<PaginatedResponse<ExecutionLogList>> {
-    const { projectId, ...rest } = params;
-    const query = projectId !== undefined ? { ...rest, project_id: projectId } : rest;
+    const query = toExecutionLogQuery(params);
     const { data, error } = await this._client.GET('/v1/execution-logs/', {
       params: { query },
     });

--- a/typescript/src/resources/execution-logs.ts
+++ b/typescript/src/resources/execution-logs.ts
@@ -33,13 +33,23 @@ type ExecutionLogQuery = NonNullable<paths['/v1/execution-logs/']['get']['parame
  * API never accepted, which now hard-400 against the strict param gate.
  */
 function toExecutionLogQuery(params: ExecutionLogListParams): ExecutionLogQuery {
+  // executed_item_id backs both the skill and evaluator filters — an evaluator's
+  // own logs carry its id there — so the two are mutually exclusive. Reject the
+  // conflict loudly rather than silently dropping one.
+  if (params.skill_id !== undefined && params.evaluator_id !== undefined) {
+    throw new ScorableError(
+      400,
+      'INVALID_EXECUTION_LOG_FILTER',
+      undefined,
+      'skill_id and evaluator_id cannot be used together',
+    );
+  }
+
   const query: Record<string, unknown> = {};
   const set = (key: string, value: unknown): void => {
     if (value !== undefined) query[key] = value;
   };
 
-  // executed_item_id backs both the skill and evaluator filters — an evaluator's
-  // own logs carry its id there — so the two are mutually exclusive in practice.
   set('executed_item_id', params.skill_id ?? params.evaluator_id);
   set('judge_id', params.judge_id);
   set('min_cost', params.cost_min);

--- a/typescript/tests/unit/execution-logs.test.ts
+++ b/typescript/tests/unit/execution-logs.test.ts
@@ -96,6 +96,13 @@ describe('ExecutionLogsResource', () => {
       expectQuery({ owner_email: 'user@scorable.ai' });
     });
 
+    it('rejects conflicting skill_id and evaluator_id instead of silently dropping one', async () => {
+      await expect(
+        client.executionLogs.list({ skill_id: 'skill-1', evaluator_id: 'eval-1' }),
+      ).rejects.toThrow('skill_id and evaluator_id cannot be used together');
+      expect(mockClient.GET).not.toHaveBeenCalled();
+    });
+
     it('passes judge_id, model, tags and search through unchanged', async () => {
       await client.executionLogs.list({
         judge_id: 'judge-1',

--- a/typescript/tests/unit/execution-logs.test.ts
+++ b/typescript/tests/unit/execution-logs.test.ts
@@ -49,4 +49,66 @@ describe('ExecutionLogsResource', () => {
       });
     });
   });
+
+  describe('list translates filter names onto the API param names', () => {
+    beforeEach(() => {
+      mockClient.setMockResponse('GET', '/v1/execution-logs/', {
+        data: { results: [], next: null, previous: null },
+        error: undefined,
+      });
+    });
+
+    const expectQuery = (query: Record<string, unknown>) =>
+      expect(mockClient.GET).toHaveBeenCalledWith('/v1/execution-logs/', {
+        params: { query },
+      });
+
+    it('maps score_min/score_max to min_score/max_score', async () => {
+      await client.executionLogs.list({ score_min: 0.2, score_max: 0.9 });
+      expectQuery({ min_score: 0.2, max_score: 0.9 });
+    });
+
+    it('maps cost_min/cost_max to min_cost/max_cost', async () => {
+      await client.executionLogs.list({ cost_min: 0.01, cost_max: 5 });
+      expectQuery({ min_cost: 0.01, max_cost: 5 });
+    });
+
+    it('maps created_at_after/created_at_before to date_from/date_to', async () => {
+      await client.executionLogs.list({
+        created_at_after: '2026-01-01T00:00:00Z',
+        created_at_before: '2026-02-01T00:00:00Z',
+      });
+      expectQuery({ date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00Z' });
+    });
+
+    it('maps skill_id to executed_item_id', async () => {
+      await client.executionLogs.list({ skill_id: 'skill-1' });
+      expectQuery({ executed_item_id: 'skill-1' });
+    });
+
+    it('maps evaluator_id to executed_item_id', async () => {
+      await client.executionLogs.list({ evaluator_id: 'eval-1' });
+      expectQuery({ executed_item_id: 'eval-1' });
+    });
+
+    it('maps owner__email to owner_email', async () => {
+      await client.executionLogs.list({ owner__email: 'user@scorable.ai' });
+      expectQuery({ owner_email: 'user@scorable.ai' });
+    });
+
+    it('passes judge_id, model, tags and search through unchanged', async () => {
+      await client.executionLogs.list({
+        judge_id: 'judge-1',
+        model: 'claude-opus-4-8',
+        tags: 'prod',
+        search: 'foo',
+      });
+      expectQuery({
+        judge_id: 'judge-1',
+        model: 'claude-opus-4-8',
+        tags: 'prod',
+        search: 'foo',
+      });
+    });
+  });
 });


### PR DESCRIPTION
## What

Adds `toExecutionLogQuery()` to `ExecutionLogsResource.list()`, translating every
public filter param onto the API's actual query-param name in one place:

| SDK param | API param |
|---|---|
| `score_min` / `score_max` | `min_score` / `max_score` |
| `cost_min` / `cost_max` | `min_cost` / `max_cost` |
| `created_at_after` / `created_at_before` | `date_from` / `date_to` |
| `skill_id`, `evaluator_id` | `executed_item_id` |
| `owner__email` | `owner_email` |
| `projectId` | `project_id` |

`judge_id`, `model`, `tags`, `search`, `page_size`, `cursor` pass through unchanged.

## Why

The API forwarded these params verbatim under names it never accepted. They
silently no-op'd before, and now hard-400 against the strict allowed-params gate
added in rs#3579. This makes every documented `list()` / `getBy*` method and the
CLI flags backed by them actually filter.

The public `ExecutionLogListParams` surface is **unchanged** → non-breaking, and
the CLI needs no edits (its flags already feed these params).

Companion API PR (wires `min_cost`/`max_cost`/`model`/`owner_email`): root-signals/rs#3603.
Control ticket: `execution-log-cli-other-broken-filters`.

## Note on the CLI

`cli/` depends on `@root-signals/scorable` as a published npm version (`^0.12.0`),
not a source link — so the CLI only picks up this fix once the SDK is released and
the CLI's dependency is bumped (a release step, not a code change). Verified
end-to-end by overlaying this build into the CLI's `node_modules`: the real CLI
binary returns correctly filtered rows for `--model`, `--score-min`, and
`--owner-email`.

## Verification

- `tests/unit/execution-logs.test.ts` — 10 passed (7 new mapping assertions).
- `type-check`, `eslint`, `prettier --check`, `build` — all clean.
- Live run against a local API: `getByScoreRange`, `getByCostRange`, `getByModel`,
  `list({model})`, `list({owner__email})` all return the expected rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution log filtering so client-side filter names are correctly translated for API requests.
  * Added support for score, cost, date range, owner email, skill, and evaluator filters.
  * Preserved additional filters such as search, ordering, tags, model, and pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->