### PR TITLE
TypeScript SDK 0.12.1

### DIFF
--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.12.1
+
+Fixes `executionLogs` filtering. Several filters were sent under param names the API doesn't accept — they silently returned unfiltered results before, and now hard-400 against the API's strict param validation.
+
+- `executionLogs.list()` and the `getBy*` helpers now translate every filter onto the API's real query-param name: `score_min`/`score_max` → `min_score`/`max_score`, `cost_min`/`cost_max` → `min_cost`/`max_cost`, `created_at_after`/`created_at_before` → `date_from`/`date_to`, `skill_id`/`evaluator_id` → `executed_item_id`, `owner__email` → `owner_email`. The public param names are unchanged, so no call sites need to change.
+- Passing both `skill_id` and `evaluator_id` (they map to the same field) now throws a 400 `ScorableError` instead of silently dropping one.
+- Bump `openapi-fetch` to 0.17.0; build under TypeScript 6.
+
 ## 0.12.0
 
 Adds the annotation-store resources for labelling datasets and calibrating evaluators.

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "TypeScript SDK for Scorable API",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release **TypeScript SDK 0.12.1**.

Fixes `executionLogs` filtering — filters were sent under param names the API doesn't accept (silently unfiltered before, hard-400 now):

- `list()` / `getBy*` translate every filter onto the API's real query-param name (`score_min`→`min_score`, `cost_min`→`min_cost`, `created_at_after`→`date_from`, `skill_id`/`evaluator_id`→`executed_item_id`, `owner__email`→`owner_email`). Public param names unchanged.
- Passing both `skill_id` and `evaluator_id` now throws a 400 `ScorableError` instead of silently dropping one.
- Bump `openapi-fetch` to 0.17.0; build under TypeScript 6.

Companion API change (adds `min_cost`/`max_cost`/`model`/`owner_email` server-side): root-signals/rs#3603 — **must be deployed to prod before this is published**, or the cost/model/owner filters 400.

After merge: `cd typescript && npm publish` (manual). Then the CLI 0.15.1 release can proceed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `executionLogs` filtering for score, cost, creation date, and owner email criteria.
  * Invalid filter parameters now return a clear `400` error instead of unfiltered results.
  * Providing both `skill_id` and `evaluator_id` now correctly returns a validation error.

* **Release**
  * Updated the package to version 0.12.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->