### PR TITLE
CLI 0.15.1 (draft — blocked on SDK 0.12.1 publish)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.15.1
+
+- Bump `@root-signals/scorable` to `^0.12.1`, which fixes `execution-log list` filters. `--score-min`/`--score-max`, `--created-at-after`/`--created-at-before`, `--owner-email`, `--evaluator-id`, and `--model` sent query-param names the API rejected (400) and now filter correctly.
+- Dependency maintenance: js-yaml, @inquirer/prompts, oxlint, typescript.
+
 ## 0.15.0
 
 - Bump `@root-signals/scorable` to `^0.12.0` for the annotation-store resources.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@root-signals/scorable-cli",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@root-signals/scorable": "^0.12.0",
+        "@root-signals/scorable": "^0.12.1",
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "commander": "^15.0.0",
@@ -892,9 +892,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -912,9 +909,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -932,9 +926,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -952,9 +943,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -972,9 +960,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -992,9 +977,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1012,9 +994,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1032,9 +1011,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1377,12 +1353,12 @@
       "license": "MIT"
     },
     "node_modules/@root-signals/scorable": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.12.0.tgz",
-      "integrity": "sha512-2RSNaEVf0QmC+Q79IWDqxCgxuZRZqoFoHBLy/FdQ4uCTkBG9mApmwlaLbzKzZlBqxnztck7Ji9P7rvUOmKAoWQ==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@root-signals/scorable/-/scorable-0.12.1.tgz",
+      "integrity": "sha512-o2eKxV3XhceuEcqwmr37UpcL9y7Vh1w88vrYPXmnw+9Uc9HYM91IcwPR39yi0sddUZqBuIjaZcAFU0/xUCCOUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "openapi-fetch": "^0.15.0"
+        "openapi-fetch": "^0.17.0"
       },
       "optionalDependencies": {
         "form-data": "^4.0.5",
@@ -2821,18 +2797,18 @@
       }
     },
     "node_modules/openapi-fetch": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.15.2.tgz",
-      "integrity": "sha512-rdYTzUmSsJevmNqg7fwUVGuKc2Gfb9h6ph74EVPkPfIGJaZTfqdIbJahtbJ3qg1LKinln30hqZniLnKpH0RJBg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
+      "integrity": "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==",
       "license": "MIT",
       "dependencies": {
-        "openapi-typescript-helpers": "^0.0.15"
+        "openapi-typescript-helpers": "^0.1.0"
       }
     },
     "node_modules/openapi-typescript-helpers": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
-      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
+      "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
       "license": "MIT"
     },
     "node_modules/ora": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/scorable-cli",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "CLI for Scorable",
   "license": "Apache-2.0",
   "author": "Scorable",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",
-    "@root-signals/scorable": "^0.12.0",
+    "@root-signals/scorable": "^0.12.1",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^15.0.0",


### PR DESCRIPTION
Release **CLI 0.15.1** — bumps `@root-signals/scorable` to `^0.12.1` so the `execution-log list` filters work (`--score-min`/`--score-max`, `--created-at-after`/`--created-at-before`, `--owner-email`, `--evaluator-id`, `--model` previously 400'd).

> ⚠️ **DRAFT — blocked on TypeScript SDK 0.12.1 being published to npm** (PR #185).
> CI will stay red until then: the lockfile still pins `scorable@0.12.0` and `npm install` can't resolve `0.12.1` yet.

## To finish (after SDK 0.12.1 is on npm)
```bash
cd cli && npm install     # resolves 0.12.1, updates package-lock.json
git commit -am "Update lockfile to scorable 0.12.1"
```
Then mark this PR ready, let CI go green, and merge. Publish with `cd cli && npm publish`.

Depends on: #185 (TypeScript SDK 0.12.1). Server-side filters: root-signals/rs#3603 (deploy to prod first).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `execution-log list` filters for score ranges, creation dates, owner email, evaluator ID, and model.

* **Release**
  * Updated the CLI to version 0.15.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->