### PR TITLE
Raise calibration example wait timeout to 300s

### DIFF
--- a/python/examples/calibration.py
+++ b/python/examples/calibration.py
@@ -5,7 +5,7 @@ from scorable import Scorable
 client = Scorable()
 
 
-def wait_for_completion(run, timeout: float = 120.0):
+def wait_for_completion(run, timeout: float = 300.0):
     deadline = time.monotonic() + timeout
     while run.status in ("pending", "running"):
         if time.monotonic() > deadline:


### PR DESCRIPTION
## What

Raise `wait_for_completion`'s default timeout in `python/examples/calibration.py` from 120s to 300s.

## Why

The rs system-test suite generates `test_sdk_examples.py` from this repo's `examples/` and runs it against a live cluster. On the encrypted `system-test (true)` (TLS) variant, real calibration runs regularly take just over 120s, so `test_calibration` deterministically hits `TimeoutError: Calibration run … did not finish within 120.0s` — while the unencrypted `(false)` variant passes.

This has been blocking otherwise-clean Dependabot PRs in root-signals/rs (e.g. django-filter #3623, openai #3622), which clone this SDK's `main` at test time. Calibration legitimately needs more than 120s in that environment; 300s gives headroom while still catching genuinely stuck runs.

## Impact

Example/doc-only change; no library or API surface affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default wait time for calibration runs from 120 to 300 seconds, reducing premature timeout errors for longer-running calibrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->