### PR TITLE
Document how prompt-test dataset columns map to prompt variables

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -725,6 +725,23 @@ evaluators:
 #     name: { type: string }
 ```
 
+#### Using a dataset
+
+Set `dataset_id` instead of `inputs` to run every item in a stored dataset.
+
+Dataset columns are matched to your `{{variables}}` **by name** — a prompt containing
+`{{text}}` needs the dataset's items to carry a variable called `text`. Import CSVs with a
+header row so the columns are named; a headerless file is read positionally as request,
+response and expected output instead.
+
+`request`, `response` and `expected_output` are special: they map onto the item's own fields
+rather than its variables, and stay addressable in a prompt, so `{{request}}` works for a
+dataset of question/answer pairs. A column that must remain a variable despite being named
+like one of those can be written as `variables.request`.
+
+An item missing a variable your prompt needs fails that item and names what was missing,
+rather than silently substituting the wrong column.
+
 Results are displayed in a table and a browser link is printed for the full comparison view.
 
 ## Development

--- a/cli/src/commands/prompt-test/init.ts
+++ b/cli/src/commands/prompt-test/init.ts
@@ -19,7 +19,11 @@ inputs:
       text: "Contact: Jane Smith (email: jane.smith@company.org, handle: @janesmith)"
 
 # Alternative to inputs: Use a dataset by ID
-# Uncomment the line below and comment out the inputs section to use a dataset instead
+# Uncomment the line below and comment out the inputs section to use a dataset instead.
+# Dataset columns are matched to {{variables}} by name, so a dataset used with the
+# prompts above needs a column named "text". When importing a CSV, include a header
+# row naming the columns; a column named request, response or expected_output maps to
+# that field on the item and is addressable as {{request}} and so on.
 # dataset_id: "<uuid>"
 
 # Models to test (each will be run with all prompt/input combinations)


### PR DESCRIPTION
Follow-up to root-signals/rs#3662, which changed prompt testing to resolve dataset variables **by name** instead of by column position.

No code change is needed in the CLI or either SDK — neither references `variable_to_column` (removed) nor `/test-datasets/` (deleted), and the `POST prompt-tests` payload is unchanged. Prompt testing is CLI-only; neither SDK exposes it.

But the behaviour a user sees does change. A prompt containing `{{text}}` now needs the dataset's items to carry a variable named `text`; previously columns mapped positionally. A headerless CSV is read as request/response/expected_output, so such a prompt would fail with `Dataset item at position 0 is missing variables: text` — a clear error, but a different one.

The init template and README both showed `dataset_id` with no explanation of the mapping at all, which made them the natural place to look once a run failed. This documents:

- columns are matched to `{{variables}}` by name; import CSVs with a header row
- `request`, `response` and `expected_output` map onto the item's own fields and stay addressable in a prompt, so `{{request}}` works for a question/answer set
- a column that must stay a variable despite being named like one of those can be written `variables.request`
- a missing variable fails that item and names it, rather than silently substituting the wrong column

Docs side is root-signals/gitbook-docs branch `document-dataset-variable-mapping`.